### PR TITLE
feat: Add proof set transaction tracking and storage

### DIFF
--- a/backend/indexer/config/events.yaml
+++ b/backend/indexer/config/events.yaml
@@ -38,6 +38,39 @@ Resources:
         Definition: "NextProvingPeriod(uint256 indexed setId, uint256 challengeEpoch, uint256 leafCount)"
         Handler: "NextProvingPeriodHandler"
 
+      - Type: "function"
+        Definition: "proposeProofSetOwner(uint256 setId, address newOwner)"
+        Handler: "TransactionHandler"
+
+      - Type: "function"
+        Definition: "claimProofSetOwnership(uint256 setId)"
+        Handler: "TransactionHandler"
+
+      # TODO: need set_id to store createProofSet transaction
+      # - Type: "function"
+      #   Definition: "createProofSet(address listenerAddr, bytes calldata extraData)"
+      #   Handler: "TransactionHandler"
+
+      - Type: "function"
+        Definition: "deleteProofSet(uint256 setId, bytes calldata extraData)"
+        Handler: "TransactionHandler"
+
+      - Type: "function"
+        Definition: "addRoots(uint256 setId, RootData[] calldata rootData, bytes calldata extraData)"
+        Handler: "TransactionHandler"
+
+      - Type: "function"
+        Definition: "scheduleRemovals(uint256 setId, uint256[] calldata rootIds, bytes calldata extraData)"
+        Handler: "TransactionHandler"
+
+      - Type: "function"
+        Definition: "provePossession(uint256 setId, Proof[] calldata proofs)"
+        Handler: "TransactionHandler"
+
+      - Type: "function"
+        Definition: "nextProvingPeriod(uint256 setId, uint256 challengeEpoch, bytes calldata extraData)"
+        Handler: "TransactionHandler"
+
   - Name: PDPService
     Address: ""
     Triggers:

--- a/backend/indexer/config/events.yaml
+++ b/backend/indexer/config/events.yaml
@@ -46,11 +46,6 @@ Resources:
         Definition: "claimProofSetOwnership(uint256 setId)"
         Handler: "TransactionHandler"
 
-      # TODO: need set_id to store createProofSet transaction
-      # - Type: "function"
-      #   Definition: "createProofSet(address listenerAddr, bytes calldata extraData)"
-      #   Handler: "TransactionHandler"
-
       - Type: "function"
         Definition: "deleteProofSet(uint256 setId, bytes calldata extraData)"
         Handler: "TransactionHandler"

--- a/backend/indexer/internal/indexer/block_processing.go
+++ b/backend/indexer/internal/indexer/block_processing.go
@@ -197,6 +197,7 @@ func (i *Indexer) processTipset(ctx context.Context, block *types.EthBlock) erro
 
 		tx := result.tx
 		tx.Timestamp = blockTimestamp
+		tx.Status = result.receipt.Status
 		txs = append(txs, tx)
 	}
 

--- a/backend/indexer/internal/infrastructure/database/transactions.go
+++ b/backend/indexer/internal/infrastructure/database/transactions.go
@@ -22,8 +22,8 @@ func (db *PostgresDB) StoreTransaction(ctx context.Context, tx *models.Transacti
 			status,
 			block_number,
 			block_hash,
-			createdAt
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		ON CONFLICT (hash) DO UPDATE SET
 			proof_set_id = EXCLUDED.proof_set_id,
 			message_id = EXCLUDED.message_id,

--- a/backend/indexer/internal/processor/handlers/proof_set_created_handler.go
+++ b/backend/indexer/internal/processor/handlers/proof_set_created_handler.go
@@ -108,6 +108,28 @@ func (h *ProofSetCreatedHandler) HandleEvent(ctx context.Context, eventLog types
 		return fmt.Errorf("failed to store event log: %w", err)
 	}
 
+	// Create new Transaction
+	transaction := &models.Transaction{
+		ReorgModel: models.ReorgModel{
+			BlockNumber: blockNumber,
+			BlockHash:   tx.BlockHash,
+		},
+		Hash:        tx.Hash,
+		ProofSetId:  setId.Int64(),
+		MessageId:   "",
+		Height:      int64(blockNumber),
+		FromAddress: tx.From,
+		ToAddress:   tx.To,
+		Value:       hexToInt64(tx.Value),
+		Method:      "createProofSet",
+		Status:      true,
+		CreatedAt:   createdAt,
+	}
+
+	if err := h.db.StoreTransaction(ctx, transaction); err != nil {
+		return fmt.Errorf("failed to store transaction: %w", err)
+	}
+
 	// Create new proof set
 	proofSet := &models.ProofSet{
 		ReorgModel: models.ReorgModel{

--- a/backend/indexer/internal/processor/handlers/transaction_handler.go
+++ b/backend/indexer/internal/processor/handlers/transaction_handler.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"pdp-explorer-indexer/internal/models"
 	"pdp-explorer-indexer/internal/types"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -34,6 +36,13 @@ func (h *TransactionHandler) HandleFunction(ctx context.Context, tx types.Transa
 
 	createdAt := time.Unix(tx.Timestamp, 0)
 
+	// Convert transaction status from hex string to boolean
+	// Any non-zero value means success, zero means failure
+	txStatus := false
+	if status, err := strconv.ParseInt(strings.TrimPrefix(tx.Status, "0x"), 16, 64); err == nil {
+		txStatus = status != 0
+	}
+
 	// TODO; missing messagecid
 	dbTx := &models.Transaction{
 		ReorgModel: models.ReorgModel{
@@ -48,7 +57,7 @@ func (h *TransactionHandler) HandleFunction(ctx context.Context, tx types.Transa
 		ToAddress:   tx.To,
 		Value:       hexToInt64(tx.Value),
 		Method:      tx.Method,
-		Status:      true,
+		Status:      txStatus,
 		CreatedAt:   createdAt,
 	}
 

--- a/backend/indexer/internal/processor/handlers/transaction_handler.go
+++ b/backend/indexer/internal/processor/handlers/transaction_handler.go
@@ -47,7 +47,7 @@ func (h *TransactionHandler) HandleFunction(ctx context.Context, tx types.Transa
 		FromAddress: tx.From,
 		ToAddress:   tx.To,
 		Value:       hexToInt64(tx.Value),
-		Method:      "",
+		Method:      tx.Method,
 		Status:      true,
 		CreatedAt:   createdAt,
 	}

--- a/backend/indexer/internal/processor/handlers/transaction_handler.go
+++ b/backend/indexer/internal/processor/handlers/transaction_handler.go
@@ -34,7 +34,7 @@ func (h *TransactionHandler) HandleFunction(ctx context.Context, tx types.Transa
 
 	createdAt := time.Unix(tx.Timestamp, 0)
 
-	// TODO; missing messagecid and method
+	// TODO; missing messagecid
 	dbTx := &models.Transaction{
 		ReorgModel: models.ReorgModel{
 			BlockNumber: blockNumber,

--- a/backend/indexer/internal/processor/handlers/transaction_handler.go
+++ b/backend/indexer/internal/processor/handlers/transaction_handler.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"pdp-explorer-indexer/internal/models"
+	"pdp-explorer-indexer/internal/types"
+	"time"
+)
+
+
+type TransactionHandler struct {
+	types.BaseHandler
+	db Database
+}
+
+func NewTransactionHandler (db Database) *TransactionHandler {
+	return &TransactionHandler{
+		BaseHandler: types.NewBaseHandler(types.HandlerTypeFunction),
+		db:          db,
+	}
+}
+
+func (h *TransactionHandler) HandleFunction(ctx context.Context, tx types.Transaction) error {
+	blockNumber, err := blockNumberToUint64(tx.BlockNumber)
+	if err != nil {
+		return fmt.Errorf("failed to parse block number: %w", err)
+	}
+
+	setId, err := getSetIdFromTxInput(tx.Input)
+	if err != nil {
+		return fmt.Errorf("failed to parse setId from transaction input: %w", err)
+	}
+
+	createdAt := time.Unix(tx.Timestamp, 0)
+
+	// TODO; missing messagecid and method
+	dbTx := &models.Transaction{
+		ReorgModel: models.ReorgModel{
+			BlockNumber: blockNumber,
+			BlockHash:   tx.BlockHash,
+		},
+		Hash:        tx.Hash,
+		ProofSetId:  setId.Int64(),
+		MessageId:   "",
+		Height:      int64(blockNumber),
+		FromAddress: tx.From,
+		ToAddress:   tx.To,
+		Value:       hexToInt64(tx.Value),
+		Method:      "",
+		Status:      true,
+		CreatedAt:   createdAt,
+	}
+
+	if err := h.db.StoreTransaction(ctx, dbTx); err != nil {
+		return fmt.Errorf("failed to store transaction: %w", err)
+	}
+
+	return nil
+}

--- a/backend/indexer/internal/processor/handlers/types.go
+++ b/backend/indexer/internal/processor/handlers/types.go
@@ -3,11 +3,8 @@ package handlers
 import (
 	"context"
 	"math/big"
-	"time"
 
 	"pdp-explorer-indexer/internal/models"
-
-	"github.com/jmoiron/sqlx/types"
 )
 
 // Database interface for handlers
@@ -38,129 +35,6 @@ type Database interface {
 
 	// Transaction methods
 	StoreTransaction(ctx context.Context, transaction *models.Transaction) error
-}
-
-// ReorgModel provides base fields and methods for reorg handling
-type ReorgModel struct {
-	ID          int64  `db:"id" json:"id"`
-	BlockNumber uint64 `db:"block_number" json:"block_number"`
-	BlockHash   string `db:"block_hash" json:"block_hash"`
-	PreviousID  *int64 `db:"previous_id" json:"previous_id,omitempty"`
-}
-
-// Transfer represents a WFIL transfer
-type Transfer struct {
-	ReorgModel            // Embed ReorgModel to inherit base fields and methods
-	FromAddress string    `db:"from_address" json:"from_address"`
-	ToAddress   string    `db:"to_address" json:"to_address"`
-	Amount      *big.Int  `db:"amount" json:"amount"`
-	TxHash      string    `db:"tx_hash" json:"tx_hash"`
-	LogIndex    string    `db:"log_index" json:"log_index"`
-	CreatedAt   time.Time `db:"created_at_time" json:"created_at"`
-}
-
-// ProofSet represents a proof set in the system
-type ProofSet struct {
-	ReorgModel                    // Embed ReorgModel to inherit base fields and methods
-	SetId               int64     `db:"set_id" json:"set_id"`
-	Owner               string    `db:"owner" json:"owner"`
-	ListenerAddr        string    `db:"listener_addr" json:"listener_addr"`
-	TotalFaultedPeriods int64    `db:"total_faulted_periods" json:"total_faulted_periods"`
-	TotalDataSize       int64    `db:"total_data_size" json:"total_data_size"`
-	TotalRoots          int64    `db:"total_roots" json:"total_roots"`
-	TotalProvedRoots    int64    `db:"total_proved_roots" json:"total_proved_roots"`
-	TotalFeePaid        *big.Int    `db:"total_fee_paid" json:"total_fee_paid"`
-	LastProvenEpoch     int64    `db:"last_proven_epoch" json:"last_proven_epoch"`
-	NextChallengeEpoch  int64    `db:"next_challenge_epoch" json:"next_challenge_epoch"`
-	TotalTransactions   int64    `db:"total_transactions" json:"total_transactions"`
-	IsActive            bool      `db:"is_active" json:"is_active"`
-	CreatedAt           time.Time `db:"created_at" json:"created_at"`
-	UpdatedAt           time.Time `db:"updated_at" json:"updated_at"`
-}
-
-type Provider struct {
-	ReorgModel
-	Address             string    `db:"address" json:"address"`
-	TotalFaultedPeriods int64    `db:"total_faulted_periods" json:"total_faulted_periods"`
-	TotalDataSize       int64    `db:"total_data_size" json:"total_data_size"`
-	ProofSetIds         []int64   `db:"proof_set_ids" json:"proof_set_ids"`
-	CreatedAt           time.Time `db:"created_at" json:"created_at"`
-	UpdatedAt           time.Time `db:"updated_at" json:"updated_at"`
-}
-
-type ProofFee struct {
-	ReorgModel
-	FeeId               string    `db:"fee_id"`
-	SetId               int64  `db:"set_id"`
-	ProofFee            *big.Int  `db:"proof_fee"`
-	FilUsdPrice         int64     `db:"fil_usd_price"`
-	FilUsdPriceExponent int32     `db:"fil_usd_price_exponent"`
-	CreatedAt           time.Time `db:"created_at"`
-}
-
-type Root struct {
-	ReorgModel
-	SetId            int64     `db:"set_id" json:"set_id"`
-	RootId           int64     `db:"root_id" json:"root_id"`
-	RawSize          int64    `db:"raw_size" json:"raw_size"`
-	Cid              string    `db:"cid" json:"cid"`
-	Removed          bool      `db:"removed" json:"removed"`
-	TotalProofs      int64    `db:"total_proofs" json:"total_proofs"`
-	TotalFaults      int64    `db:"total_faults" json:"total_faults"`
-	LastProvenEpoch  int64    `db:"last_proven_epoch" json:"last_proven_epoch"`
-	LastFaultedEpoch int64    `db:"last_faulted_epoch" json:"last_faulted_epoch"`
-	CreatedAt        time.Time `db:"created_at" json:"created_at"`
-	UpdatedAt        time.Time `db:"updated_at" json:"updated_at"`
-}
-
-type Proof struct {
-	ReorgModel
-	SetId       int64  `db:"set_id"`
-	RootId      int64  `db:"root_id"`
-	ProofOffset      int64    `db:"proof_offset"`
-	LeafHash    string    `db:"leaf_hash"`
-	MerkleProof []byte    `db:"merkle_proof"`
-	ProvenAt    time.Time `db:"proven_at"`
-	CreatedAt   time.Time `db:"created_at"`
-}
-
-type FaultRecord struct {
-	ReorgModel
-	SetId          int64  `db:"set_id"`
-	ChallengeEpoch int64    `db:"challenge_epoch"`
-	PeriodsFaulted int64    `db:"periods_faulted"`
-	Deadline       int64    `db:"deadline"`
-	FaultedAt      time.Time `db:"faulted_at"`
-	CreatedAt      time.Time `db:"created_at"`
-}
-
-type EventLog struct {
-	ReorgModel
-
-	SetId           int64          `db:"set_id"`
-	Address         string         `db:"address"`
-	Name            string         `db:"name"`
-	Data            types.JSONText `db:"data"`
-	LogIndex        int64          `db:"log_index"`
-	Removed         bool           `db:"removed"`
-	Topics          []string       `db:"topics"`
-	TransactionHash string         `db:"transaction_hash"`
-	CreatedAt       time.Time      `db:"created_at"`
-}
-
-type TTransaction struct {
-	ReorgModel
-
-	Hash        string    `db:"hash"`
-	ProofSetId  int64     `db:"proof_set_id"`
-	MessageId   string    `db:"message_id"`
-	Height      int64     `db:"height"`
-	FromAddress string    `db:"from_address"`
-	ToAddress   string    `db:"to_address"`
-	Value       int64     `db:"value"`
-	Method      string    `db:"method"`
-	Status      bool      `db:"status"`
-	CreatedAt   time.Time `db:"created_at"`
 }
 
 type Cid struct {

--- a/backend/indexer/internal/processor/handlers/utils.go
+++ b/backend/indexer/internal/processor/handlers/utils.go
@@ -50,6 +50,24 @@ func getSetIdFromTopic(topic string) (*big.Int, error) {
 	return setId, nil
 }
 
+// GetSetIdFromTxInput parses a setId from a transaction input
+func getSetIdFromTxInput(input string) (*big.Int, error) {
+	if strings.HasPrefix(input, hexPrefix) {
+		input = input[2:]
+	}
+
+	// remove function selector (4 bytes - 8 chars)
+	input = input[8:]
+
+	// parse next 32 bytes to get setId
+	setId, ok := new(big.Int).SetString(input[:64], 16)
+	if !ok {
+		return nil, &ParseError{Field: "setId", Msg: "invalid hex value"}
+	}
+
+	return setId, nil
+}
+
 // GetAddressFromTopic parses an Ethereum address from an event topic
 func getAddressFromTopic(topic string) (string, error) {
 	if strings.HasPrefix(topic, hexPrefix) {

--- a/backend/indexer/internal/processor/processor.go
+++ b/backend/indexer/internal/processor/processor.go
@@ -55,6 +55,7 @@ var handlerRegistry = map[string]HandlerFactory{
 	"NextProvingPeriodHandler":    func(db handlers.Database) types.Handler { return handlers.NewNextProvingPeriodHandler(db) },
 	"PossessionProvenHandler":     func(db handlers.Database) types.Handler { return handlers.NewPossessionProvenHandler(db) },
 	"FaultRecordHandler":          func(db handlers.Database) types.Handler { return handlers.NewFaultRecordHandler(db) },
+	"TransactionHandler":          func(db handlers.Database) types.Handler { return handlers.NewTransactionHandler(db) },
 }
 
 func RegisterHandlerFactory(name string, factory HandlerFactory) {

--- a/backend/indexer/internal/processor/processor.go
+++ b/backend/indexer/internal/processor/processor.go
@@ -20,6 +20,7 @@ type Trigger struct {
 	Type       string `yaml:"Type"`       // "event" or "function"
 	Definition string `yaml:"Definition"` // Event or function definition
 	Handler    string `yaml:"Handler"`
+	MethodName string `yaml:"MethodName"`
 }
 
 type ContractConfig struct {
@@ -235,9 +236,10 @@ func (p *Processor) processTransaction(ctx context.Context, tx types.Transaction
 			matchedContract = &contract
 			for _, trigger := range contract.Triggers {
 				// Generate function signature
-				funcSig := GenerateFunctionSignature(trigger.Definition)
+				funcSig, methodName := GenerateFunctionSignature(trigger.Definition)
 				if trigger.Type == types.HandlerTypeFunction && strings.EqualFold(funcSig, functionSelector) {
 					matchedTrigger = &trigger
+					matchedTrigger.MethodName = methodName
 					break
 				}
 			}
@@ -261,6 +263,7 @@ func (p *Processor) processTransaction(ctx context.Context, tx types.Transaction
 	}
 
 	// Process the function call
+	tx.Method = matchedTrigger.MethodName
 	return handler.HandleFunction(ctx, tx)
 }
 

--- a/backend/indexer/internal/processor/signatures.go
+++ b/backend/indexer/internal/processor/signatures.go
@@ -50,13 +50,13 @@ func GenerateEventSignature(eventDef string) string {
 }
 
 // GenerateFunctionSignature generates the function selector (first 4 bytes) from its definition
-func GenerateFunctionSignature(funcDef string) string {
+func GenerateFunctionSignature(funcDef string) (string, string) {
 	// Split into name and parameters
 	openParen := strings.Index(funcDef, "(")
 	closeParen := strings.LastIndex(funcDef, ")")
 	
 	if openParen == -1 || closeParen == -1 {
-		return ""
+		return "", ""
 	}
 	
 	name := funcDef[:openParen]
@@ -68,5 +68,5 @@ func GenerateFunctionSignature(funcDef string) string {
 	hasher := sha3.NewLegacyKeccak256()
 	hasher.Write([]byte(canonicalSig))
 	hash := hasher.Sum(nil)
-	return "0x" + hex.EncodeToString(hash[:4])
+	return "0x" + hex.EncodeToString(hash[:4]), name
 }

--- a/backend/indexer/internal/types/types.go
+++ b/backend/indexer/internal/types/types.go
@@ -43,6 +43,7 @@ type Transaction struct {
 	Input                string        `json:"input"`
 	Timestamp            int64         `json:"timestamp"`
 	AccessList           []interface{} `json:"accessList"`
+	Method               string        `json:"method"`
 }
 
 // TransactionReceipt represents a blockchain transaction receipt

--- a/backend/indexer/internal/types/types.go
+++ b/backend/indexer/internal/types/types.go
@@ -41,9 +41,12 @@ type Transaction struct {
 	S                    string        `json:"s"`
 	MaxPriorityFeePerGas string        `json:"maxPriorityFeePerGas"`
 	Input                string        `json:"input"`
-	Timestamp            int64         `json:"timestamp"`
 	AccessList           []interface{} `json:"accessList"`
+
+	// These are manually added
+	Timestamp            int64         `json:"timestamp"`
 	Method               string        `json:"method"`
+	Status               string        `json:"status"`
 }
 
 // TransactionReceipt represents a blockchain transaction receipt

--- a/backend/indexer/internal/types/types.go
+++ b/backend/indexer/internal/types/types.go
@@ -11,13 +11,13 @@ type Log struct {
 	Topics           []string `json:"topics"`
 	Data             string   `json:"data"`
 	Removed          bool     `json:"removed"`
-	LogIndex         string   `json:"log_index"`
-	BlockNumber      string   `json:"block_number"`
-	BlockHash        string   `json:"block_hash"`
-	TransactionHash  string   `json:"transaction_hash"`
-	TransactionIndex string   `json:"transaction_index"`
-	From             string   `json:"from"`
-	To               string   `json:"to"`
+	LogIndex         string   `json:"logIndex"`
+	BlockNumber      string   `json:"blockNumber"`
+	BlockHash        string   `json:"blockHash"`
+	TransactionHash  string   `json:"transactionHash"`
+	TransactionIndex string   `json:"transactionIndex"`
+
+	// Manually added
 	Timestamp        int64    `json:"timestamp"`
 }
 


### PR DESCRIPTION
This PR adds functionality to track and store transactions related to proof sets:

- Add transaction handler to process and store proof set-related transactions
- Implement proof set ID extraction from transaction input
- Store transaction metadata including block info, addresses, and timestamps
- Update database operations for transaction storage

Note: MessageCID field is currently marked as TODO and will need to be implemented in a follow-up PR.