### PR TITLE
Refactor: Add default config values and rename events to triggers

### DIFF
--- a/backend/indexer/.env.example
+++ b/backend/indexer/.env.example
@@ -4,6 +4,5 @@ DATABASE_URL=
 # Indexer Configuration
 LOTUS_API_ENDPOINT=
 LOTUS_API_KEY=
-LOTUS_SOCKET_URL= # Not using it anywhere right now, but still required
-EVENTS_FILE_PATH= # Path to the events.yaml file, e.g./config/events.yaml
-START_BLOCK= # Start block number, optional`
+TRIGGERS_CONFIG= # Path to the events.yaml file, e.g./config/pdp.yaml
+START_BLOCK= # Start block number, optional

--- a/backend/indexer/internal/indexer/indexer.go
+++ b/backend/indexer/internal/indexer/indexer.go
@@ -39,7 +39,7 @@ func NewIndexer(db *database.PostgresDB, cfg *config.Config) (*Indexer, error) {
 
 func (i *Indexer) InitEventProcessor() error {
 	var err error
-	i.processor, err = processor.NewProcessor(i.cfg.EventsFilePath, i.db)
+	i.processor, err = processor.NewProcessor(i.cfg.TriggersConfig, i.db)
 	if err != nil {
 		return fmt.Errorf("failed to initialize event processor: %w", err)
 	}

--- a/backend/indexer/internal/infrastructure/config/config.go
+++ b/backend/indexer/internal/infrastructure/config/config.go
@@ -8,12 +8,18 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// Default configuration values
+const (
+	DefaultDatabaseURL      = "postgresql://postgres:postgres@localhost:5432/pdp?sslmode=disable"
+	DefaultTriggersConfigPath   = "./config/pdp.yaml"
+	DefaultLotusAPIEndpoint = "https://api.node.glif.io/rpc/v1"
+)
+
 type Config struct {
 	DatabaseURL string
-	EventsFilePath   string
+	TriggersConfig   string
 	LotusAPIEndpoint string
 	LotusAPIKey      string
-	LotusSocketUrl   string
 	StartBlock       uint64
 }
 
@@ -27,28 +33,29 @@ func LoadConfig() (*Config, error) {
 	// Database configuration
 	config.DatabaseURL = os.Getenv("DATABASE_URL")
 	if config.DatabaseURL == "" {
-		return nil, fmt.Errorf("DATABASE_URL is required")
+		config.DatabaseURL = DefaultDatabaseURL
+		fmt.Println("Using default DATABASE_URL:", config.DatabaseURL)
 	}
 
-	config.EventsFilePath = os.Getenv("EVENTS_FILE_PATH")
-	fmt.Println("EventsFilePath:", config.EventsFilePath)
-	if config.EventsFilePath == "" {
-		return nil, fmt.Errorf("EVENTS_FILE_PATH is required")
+	config.TriggersConfig = os.Getenv("TRIGGERS_CONFIG")
+	if config.TriggersConfig == "" {
+		config.TriggersConfig = DefaultTriggersConfigPath
+		fmt.Println("Using default TriggersConfig:", config.TriggersConfig)
+	} else {
+		fmt.Println("TriggersConfig:", config.TriggersConfig)
 	}
 
 	config.LotusAPIEndpoint = os.Getenv("LOTUS_API_ENDPOINT")
-	fmt.Println("LotusAPIEndpoint:", config.LotusAPIEndpoint)
 	if config.LotusAPIEndpoint == "" {
-		return nil, fmt.Errorf("LOTUS_API_ENDPOINT is required")
+		config.LotusAPIEndpoint = DefaultLotusAPIEndpoint
+		fmt.Println("Using default LotusAPIEndpoint:", config.LotusAPIEndpoint)
+	} else {
+		fmt.Println("LotusAPIEndpoint:", config.LotusAPIEndpoint)
 	}
 
 	config.LotusAPIKey = os.Getenv("LOTUS_API_KEY")
-	fmt.Println("LotusAPIKey:", config.LotusAPIKey)
-
-	config.LotusSocketUrl = os.Getenv("LOTUS_SOCKET_URL")
-	fmt.Println("LotusSocketUrl:", config.LotusSocketUrl)
-	if config.LotusSocketUrl == "" {
-		return nil, fmt.Errorf("LOTUS_SOCKET_URL is required")
+	if config.LotusAPIKey == "" {
+		fmt.Println("No LOTUS_API_KEY specified, this will result in rate limits on rpc calls")
 	}
 
 	// Parse StartBlock configuration


### PR DESCRIPTION
- Add default values for database, API endpoint and config paths
- Rename EventsFilePath to TriggersConfig for better clarity
- Remove unused LotusSocketUrl config

Breaking change: EVENTS_FILE_PATH env var is now TRIGGERS_CONFIG