### PR TITLE
fix: improve queries accuracy and timestamp display

### DIFF
--- a/client/src/pages/ProofSetDetails.tsx
+++ b/client/src/pages/ProofSetDetails.tsx
@@ -155,13 +155,17 @@ export const ProofSetDetails = () => {
               <span className="font-medium">Last Proven:</span>
               <span>
                 {proofSet.lastProvenEpoch
-                  ? formatEpochTime(proofSet.lastProvenEpoch)
+                  ? proofSet.lastProvenEpoch.toLocaleString()
                   : 'Never'}
               </span>
             </div>
             <div className="flex justify-between border-b py-2">
               <span className="font-medium">Next Challenge:</span>
-              <span>{formatEpochTime(proofSet.nextChallengeEpoch)}</span>
+              <span>
+                {proofSet.nextChallengeEpoch
+                  ? proofSet.nextChallengeEpoch.toLocaleString()
+                  : 'N/A'}
+              </span>
             </div>
             <div className="flex justify-between border-b py-2">
               <span className="font-medium">Created At:</span>


### PR DESCRIPTION
This PR includes several improvements to data accuracy and display:

Query improvements:
- Handle chain reorgs by selecting proof sets with highest block number
- Fix unique data size calculation to use actual root CIDs
- Update proof count to use proofs table instead of proof_fees

UI improvements:
- Update display format for Last Proven and Next Challenge

These changes ensure more accurate data representation and better user experience.