### PR TITLE
refactor: Optimize indexer pipeline with O(1) lookups and consistent pointer usage

### DIFF
--- a/backend/indexer/Makefile
+++ b/backend/indexer/Makefile
@@ -21,7 +21,7 @@ AIR=$(GOPATH)/bin/air
 
 # Build and run
 build:
-	$(GOBUILD) $(LDFLAGS) -o bin/$(BINARY_NAME) .
+	$(GOBUILD) $(LDFLAGS) -o bin/$(BINARY_NAME) ./cmd/indexer
 
 run: build
 	./bin/$(BINARY_NAME)

--- a/backend/indexer/internal/indexer/polling.go
+++ b/backend/indexer/internal/indexer/polling.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	minPollingInterval = 30 * time.Second
+	minPollingInterval = 120 * time.Second
 	maxPollingInterval = 5 * time.Minute
 	maxRetries         = 3
 	maxBlocksPerBatch  = 5 // Maximum number of blocks to process in one batch

--- a/backend/indexer/internal/processor/handlers/base_handler.go
+++ b/backend/indexer/internal/processor/handlers/base_handler.go
@@ -16,12 +16,12 @@ const (
 
 // EventHandler is the interface for handling event logs
 type EventHandler interface {
-	HandleEvent(ctx context.Context, log types.Log, tx *types.Transaction) error
+	HandleEvent(ctx context.Context, log *types.Log, tx *types.Transaction) error
 }
 
 // FunctionHandler is the interface for handling function calls
 type FunctionHandler interface {
-	HandleFunction(ctx context.Context, tx types.Transaction) error
+	HandleFunction(ctx context.Context, tx *types.Transaction) error
 }
 
 // Handler is a combined interface that can handle both events and functions
@@ -46,10 +46,10 @@ func (h *BaseHandler) GetType() string {
 }
 
 // Default implementations that return errors for unimplemented methods
-func (h *BaseHandler) HandleEvent(ctx context.Context, log types.Log, tx *types.Transaction) error {
+func (h *BaseHandler) HandleEvent(ctx context.Context, log *types.Log, tx *types.Transaction) error {
 	return fmt.Errorf("HandleEvent not implemented for this handler")
 }
 
-func (h *BaseHandler) HandleFunction(ctx context.Context, tx types.Transaction) error {
+func (h *BaseHandler) HandleFunction(ctx context.Context, tx *types.Transaction) error {
 	return fmt.Errorf("HandleFunction not implemented for this handler")
 }

--- a/backend/indexer/internal/processor/handlers/fault_record_handler.go
+++ b/backend/indexer/internal/processor/handlers/fault_record_handler.go
@@ -59,7 +59,7 @@ func NewFaultRecordHandler(db Database, contractAddress string, lotusAPIEndpoint
 // FaultRecordHandler handle FaultRecord events on PDPServiceListener
 // event Def - FaultRecord(uint256 indexed proofSetId, uint256 periodsFaulted, uint256 deadline)
 // function in which FaultRecord is emitted - nextProvingPeriod(uint256 proofSetId, uint256 challengeEpoch, uint256 /*leafCount*/, bytes calldata)
-func (h *FaultRecordHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *FaultRecordHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	// Parse setId from topics
 	setId, err := getSetIdFromTopic(eventLog.Topics[1])
 	if err != nil {

--- a/backend/indexer/internal/processor/handlers/next_proving_period_handler.go
+++ b/backend/indexer/internal/processor/handlers/next_proving_period_handler.go
@@ -28,7 +28,7 @@ func NewNextProvingPeriodHandler(db Database) *NextProvingPeriodHandler {
 
 // NextProvingPeriodHandler handles NextProvingPeriod events
 // event Def - NextProvingPeriod(uint256 indexed setId, uint256 challengeEpoch, uint256 /*leafCount*/)
-func (h *NextProvingPeriodHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *NextProvingPeriodHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	log.Printf("Processing NextProvingPeriod event. Data: %s", eventLog.Data)
 
 	// Parse setId from topics

--- a/backend/indexer/internal/processor/handlers/possession_proven_handler.go
+++ b/backend/indexer/internal/processor/handlers/possession_proven_handler.go
@@ -44,7 +44,7 @@ func NewPossessionProvenHandler(db Database) *PossessionProvenHandler {
 //		bytes32 leaf;
 //		bytes32[] proof;
 //	}
-func (h *PossessionProvenHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *PossessionProvenHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	log.Printf("Processing PossessionProven event. Data: %s", eventLog.Data)
 
 	// Parse setId from topics

--- a/backend/indexer/internal/processor/handlers/proof_fee_paid_handler.go
+++ b/backend/indexer/internal/processor/handlers/proof_fee_paid_handler.go
@@ -28,7 +28,7 @@ func NewProofFeePaidHandler(db Database) *ProofFeePaidHandler {
 }
 
 // ProofFeePaidHandler handles ProofFeePaid events
-func (h *ProofFeePaidHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *ProofFeePaidHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	log.Printf("Processing ProofFeePaid event. Topics: %v, Data: %s", eventLog.Topics, eventLog.Data)
 
 	// Event: ProofFeePaid(uint256 indexed setId, uint256 fee, uint64 price, int32 expo)

--- a/backend/indexer/internal/processor/handlers/proof_set_created_handler.go
+++ b/backend/indexer/internal/processor/handlers/proof_set_created_handler.go
@@ -51,7 +51,7 @@ func ParseTransactionInput(input string) (string, error) {
 	return address, nil
 }
 
-func (h *ProofSetCreatedHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *ProofSetCreatedHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	log.Printf("Handling ProofSetCreated event: %v\n", eventLog)
 	// Parse Block Number
 	blockNumber, err := blockNumberToUint64(eventLog.BlockNumber)

--- a/backend/indexer/internal/processor/handlers/proof_set_deleted_handler.go
+++ b/backend/indexer/internal/processor/handlers/proof_set_deleted_handler.go
@@ -27,7 +27,7 @@ func NewProofSetDeletedHandler(db Database) *ProofSetDeletedHandler {
 }
 
 // ProofSetDeletedHandler handles ProofSetDeleted events
-func (h *ProofSetDeletedHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *ProofSetDeletedHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	log.Printf("Processing ProofSetDeleted event. Data: %s", eventLog.Data)
 
 	// Parse setId from topics

--- a/backend/indexer/internal/processor/handlers/proof_set_empty_handler.go
+++ b/backend/indexer/internal/processor/handlers/proof_set_empty_handler.go
@@ -30,7 +30,7 @@ func NewProofSetEmptyHandler(db Database) *ProofSetEmptyHandler {
 
 
 // ProofSetEmptyHandler handles ProofSetEmpty events
-func (h *ProofSetEmptyHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *ProofSetEmptyHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	log.Printf("Processing ProofSetEmpty event. Data: %s", eventLog.Data)
 
 	// Parse setId from topics

--- a/backend/indexer/internal/processor/handlers/proof_set_owner_changed_handler.go
+++ b/backend/indexer/internal/processor/handlers/proof_set_owner_changed_handler.go
@@ -28,7 +28,7 @@ func NewProofSetOwnerChangedHandler(db Database) *ProofSetOwnerChangedHandler {
 
 // ProofSetOwnerChangedHandler handles ProofSetOwnerChanged events
 // event Def - ProofSetOwnerChanged(uint256 indexed setId, address indexed oldOwner, address indexed newOwner)
-func (h *ProofSetOwnerChangedHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *ProofSetOwnerChangedHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	if len(eventLog.Topics) < 4 {
 		return fmt.Errorf("invalid number of topics for ProofSetOwnerChanged event: got %d, want at least 4", len(eventLog.Topics))
 	}

--- a/backend/indexer/internal/processor/handlers/roots_added_handler.go
+++ b/backend/indexer/internal/processor/handlers/roots_added_handler.go
@@ -31,7 +31,7 @@ func NewRootsAddedHandler(db Database) *RootsAddedHandler {
 }
 
 // RootsAddedHandler handles RootsAdded events
-func (h *RootsAddedHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *RootsAddedHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	log.Printf("Processing RootsAdded event. Data: %s, Transaction input: %s", eventLog.Data, tx.Input)
 
 	// Parse setId from topics

--- a/backend/indexer/internal/processor/handlers/roots_remove_handler.go
+++ b/backend/indexer/internal/processor/handlers/roots_remove_handler.go
@@ -29,7 +29,7 @@ func NewRootsRemovedHandler(db Database) *RootsRemovedHandler {
 
 
 // RootsRemovedHandler handles RootsRemoved events
-func (h *RootsRemovedHandler) HandleEvent(ctx context.Context, eventLog types.Log, tx *types.Transaction) error {
+func (h *RootsRemovedHandler) HandleEvent(ctx context.Context, eventLog *types.Log, tx *types.Transaction) error {
 	log.Printf("Processing RootsRemoved event. Data: %s", eventLog.Data)
 
 	// Parse setId from topics

--- a/backend/indexer/internal/processor/handlers/transaction_handler.go
+++ b/backend/indexer/internal/processor/handlers/transaction_handler.go
@@ -24,7 +24,7 @@ func NewTransactionHandler (db Database) *TransactionHandler {
 	}
 }
 
-func (h *TransactionHandler) HandleFunction(ctx context.Context, tx types.Transaction) error {
+func (h *TransactionHandler) HandleFunction(ctx context.Context, tx *types.Transaction) error {
 	blockNumber, err := blockNumberToUint64(tx.BlockNumber)
 	if err != nil {
 		return fmt.Errorf("failed to parse block number: %w", err)

--- a/backend/indexer/internal/types/types.go
+++ b/backend/indexer/internal/types/types.go
@@ -41,6 +41,7 @@ type Transaction struct {
 	AccessList           []interface{} `json:"accessList"`
 
 	// These are manually added
+	Logs                 []Log         `json:"logs"`
 	Timestamp            int64         `json:"timestamp"`
 	Method               string        `json:"method"`
 	MessageCid           string        `json:"messageCid"`


### PR DESCRIPTION
### Changes
- Implemented O(1) lookups using optimized maps for contracts and triggers
- Standardized pointer usage across handlers and processor interfaces
- Removed redundant logging and reduced memory allocations
- Fixed Makefile build command to target correct directory

### Performance Improvements
- Reduced lookup complexity from O(n*m) to O(1)
- Minimized memory allocations with pre-allocated maps
- Improved contract address matching with normalized keys