### PR TITLE
Fix: show all roots heatmap

### DIFF
--- a/backend/server/internal/handlers/handlers.go
+++ b/backend/server/internal/handlers/handlers.go
@@ -26,7 +26,7 @@ type Service interface {
 	GetProviderActivities(providerID string, activityType string) ([]Activity, error)
 	GetProofSetEventLogs(proofSetID string, filter string, offset, limit int) ([]EventLog, int, error)
 	GetProofSetTxs(proofSetID string, filter string, offset, limit int) ([]Transaction, int, error)
-	GetProofSetRoots(proofSetID string, offset, limit int) ([]Root, int, error)
+	GetProofSetRoots(proofSetID string, orderBy, order string, offset, limit int) ([]Root, int, error)
 }
 
 type Provider struct {
@@ -432,9 +432,19 @@ func (h *Handler) GetProofSetEventLogs(c *gin.Context) {
 // GET /proofsets/:proofSetId/roots
 func (h *Handler) GetProofSetRoots(c *gin.Context) {
 	proofSetID := c.Param("proofSetId")
-	offset, limit := getPaginationParams(c)
+	orderBy := c.DefaultQuery("orderBy", "rootId")
+	order := c.DefaultQuery("order", "desc")
+	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
 
-	roots, total, err := h.svc.GetProofSetRoots(proofSetID, offset, limit)
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	roots, total, err := h.svc.GetProofSetRoots(proofSetID, orderBy, order, offset, limit)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/backend/server/internal/repository/repository.go
+++ b/backend/server/internal/repository/repository.go
@@ -1064,7 +1064,7 @@ func (r *Repository) GetProofSetTxs(ctx context.Context, proofSetID string, filt
 }
 
 // GetProofSetRoots retrieves roots for a specific proof set with pagination
-func (r *Repository) GetProofSetRoots(ctx context.Context, proofSetID string, offset, limit int) ([]Root, int, error) {
+func (r *Repository) GetProofSetRoots(ctx context.Context, proofSetID string, orderBy, order string, offset, limit int) ([]Root, int, error) {
 	// Get total count of event logs
 	var total int
 	totalFilterQuery := `
@@ -1101,9 +1101,13 @@ func (r *Repository) GetProofSetRoots(ctx context.Context, proofSetID string, of
 			last_faulted_at,
 			created_at
 		FROM LatestRoots
-		ORDER BY root_id
-		LIMIT $2 OFFSET $3
-	`;
+		`;
+		if orderBy != "" {
+			query += fmt.Sprintf(" ORDER BY %s %s", orderBy, order)
+		}
+		query += `
+			LIMIT $2 OFFSET $3
+		`;
 	// Get roots
 	rows, err := r.db.Query(ctx, query, proofSetID, limit, offset)
 	if err != nil {

--- a/backend/server/internal/service/service.go
+++ b/backend/server/internal/service/service.go
@@ -271,8 +271,8 @@ func (s *Service) GetProofSetTxs(proofSetID string, filter string, offset, limit
 	return result, total, nil
 }
 
-func (s *Service) GetProofSetRoots(proofSetID string, offset, limit int) ([]handlers.Root, int, error) {
-	roots, total, err := s.repo.GetProofSetRoots(context.Background(), proofSetID, offset, limit)
+func (s *Service) GetProofSetRoots(proofSetID string, orderBy, order string, offset, limit int) ([]handlers.Root, int, error) {
+	roots, total, err := s.repo.GetProofSetRoots(context.Background(), proofSetID, orderBy, order, offset, limit)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get proof set roots: %w", err)
 	}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/material": "^6.4.4",
         "@mui/x-data-grid": "^7.26.0",
         "@radix-ui/react-accordion": "^1.2.3",
+        "@radix-ui/react-collapsible": "^1.1.3",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "@mui/material": "^6.4.4",
     "@mui/x-data-grid": "^7.26.0",
     "@radix-ui/react-accordion": "^1.2.3",
+    "@radix-ui/react-collapsible": "^1.1.3",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",

--- a/client/src/api/apiService.ts
+++ b/client/src/api/apiService.ts
@@ -221,10 +221,12 @@ export const getProofSetTxs = async (
 export const getProofSetRoots = async (
   proofSetId: string,
   offset: number = 0,
-  limit: number = 10
+  limit: number = 10,
+  orderBy: string = 'root_id',
+  order: string = 'asc'
 ) => {
   const response = await getRequest(
-    `/proofsets/${proofSetId}/roots?offset=${offset}&limit=${limit}`
+    `/proofsets/${proofSetId}/roots?offset=${offset}&limit=${limit}&orderBy=${orderBy}&order=${order}`
   )
   return {
     data: {

--- a/client/src/components/ui/collapsible.tsx
+++ b/client/src/components/ui/collapsible.tsx
@@ -1,0 +1,9 @@
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+const Collapsible = CollapsiblePrimitive.Root
+
+const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
+
+const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }


### PR DESCRIPTION
Changes -

- improved `api/proofsets/:set_id/roots` route to accept orderBy and order as query parameters
- separete state for roots and heatmap roots