### PR TITLE
Fix(indexer): keep same nextChallengeEpoch till next NextProvingPeriod

### DIFF
--- a/backend/indexer/internal/processor/handlers/possession_proven_handler.go
+++ b/backend/indexer/internal/processor/handlers/possession_proven_handler.go
@@ -148,7 +148,6 @@ func (h *PossessionProvenHandler) HandleEvent(ctx context.Context, eventLog *typ
 
 		proofSet.TotalProvedRoots += int64(len(uniqueRootIds))
 		proofSet.LastProvenEpoch = int64(blockNumber)
-		proofSet.NextChallengeEpoch = int64(0)
 		proofSet.UpdatedAt = timestamp
 		proofSet.BlockNumber = blockNumber
 		proofSet.BlockHash = eventLog.BlockHash


### PR DESCRIPTION
This PR introduces fix in Indexer handler (`possession_proven_handler.go`):

- Don't update proofSet's `nextChallengeEpoch` until next `NextProvingPeriod` pdp event