### PR TITLE
Containerise the PDP indexer, API and frontend

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,64 @@
+name: Container
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit SHA to publish'
+        required: true
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        context:
+          - backend/indexer
+          - backend/server
+          - client
+    env:
+      REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sha || github.ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.REF }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            prefix=${{ matrix.context }}-
+          tags: |
+            type=semver,pattern={{raw}}
+            type=ref,event=branch
+            type=raw,value=${{ env.REF }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/backend/indexer/Dockerfile
+++ b/backend/indexer/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.22-bullseye AS build
+
+WORKDIR /go/src/pdp-explorer/backend/indexer
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o /go/bin/pdp-indexer ./cmd/indexer
+
+FROM gcr.io/distroless/cc
+COPY --from=build /go/bin/pdp-indexer /usr/bin/
+
+ENTRYPOINT ["/usr/bin/pdp-indexer"]

--- a/backend/server/Dockerfile
+++ b/backend/server/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.21-bullseye AS build
+
+WORKDIR /go/src/pdp-explorer/backend/server
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -o /go/bin/pdp-api ./cmd
+
+FROM gcr.io/distroless/cc
+COPY --from=build /go/bin/pdp-api /usr/bin/
+
+ENTRYPOINT ["/usr/bin/pdp-api"]

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /usr/src/pdp-explorer/client
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /usr/src/pdp-explorer/client/dist /usr/share/nginx/html
+RUN rm /etc/nginx/conf.d/default.conf
+
+RUN echo 'server { \
+    listen 80; \
+    server_name localhost; \
+    location / { \
+        root /usr/share/nginx/html; \
+        index index.html; \
+        try_files $uri $uri/ /index.html; \
+    } \
+}' > /etc/nginx/conf.d/default.conf
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/client/src/data/dummyData.ts
+++ b/client/src/data/dummyData.ts
@@ -50,20 +50,23 @@ export const dummyProofSets = {
   },
 }
 
-const createHeatmapData = () => {
-  const rows = 5
-  const cols = 7
-  return Array(rows)
-    .fill(null)
-    .map(() =>
-      Array(cols)
-        .fill(null)
-        .map(() => ({
-          status: ['idle', 'success', 'failed'][Math.floor(Math.random() * 3)],
-          rootPieceId: 'root-' + Math.random().toString(36).substr(2, 9),
-        }))
-    )
-}
+// Commented out to avoid build error from `npm run build`:
+// error TS6133: 'createHeatmapData' is declared but its value is never read.
+
+// const createHeatmapData = () => {
+//   const rows = 5
+//   const cols = 7
+//   return Array(rows)
+//     .fill(null)
+//     .map(() =>
+//       Array(cols)
+//         .fill(null)
+//         .map(() => ({
+//           status: ['idle', 'success', 'failed'][Math.floor(Math.random() * 3)],
+//           rootPieceId: 'root-' + Math.random().toString(36).substr(2, 9),
+//         }))
+//     )
+// }
 
 export const dummyProofSetDetails = {
   proofSetId: 'ps-123456',


### PR DESCRIPTION
Add dockerfiles for all three components of the PDP explorer.

Add CI to automatically build and publish images to GHCR, with option to manually publish a specific commit SHA.