### PR TITLE
Use commit sha for container tagging

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -27,7 +27,7 @@ jobs:
           - backend/server
           - client
     env:
-      REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sha || github.ref }}
+      REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sha || github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Use commit sha for container tagging to avoid re-use of tags and explicit deployment instructions.