### PR TITLE
Fix: set's leaf count for historical recovery

### DIFF
--- a/backend/indexer/Makefile
+++ b/backend/indexer/Makefile
@@ -75,6 +75,7 @@ migrate-up:
 	PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -f migrations/000106_create_proof_fees_table.up.sql
 	PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -f migrations/000107_create_proofs_table.up.sql
 	PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -f migrations/000108_create_fault_records_table.up.sql
+	PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -f migrations/000201_add_challenge_range_to_proof_sets.up.sql
 
 
 migrate-down:
@@ -88,5 +89,6 @@ migrate-down:
 	PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -f migrations/000106_create_proof_fees_table.down.sql
 	PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -f migrations/000107_create_proofs_table.down.sql
 	PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -f migrations/000108_create_fault_records_table.down.sql
+	PGPASSWORD=postgres psql -h localhost -U postgres -d postgres -f migrations/000201_add_challenge_range_to_proof_sets.down.sql
 
 	

--- a/backend/indexer/internal/contract/constants.go
+++ b/backend/indexer/internal/contract/constants.go
@@ -2,3 +2,6 @@ package contract
 
 // NB: taken from https://github.com/FilOzone/pdp/blob/main/src/SimplePDPService.sol#L154
 const NumChallenges = 5
+
+// NB: taken from https://github.com/FilOzone/pdp/blob/830396cafd45e696348edcbce5c114725d6d9b32/src/PDPVerifier.sol#L31
+const LeafSize = 32

--- a/backend/indexer/internal/models/proof_set.go
+++ b/backend/indexer/internal/models/proof_set.go
@@ -17,6 +17,7 @@ type ProofSet struct {
 	TotalFeePaid        *big.Int    `db:"total_fee_paid" json:"total_fee_paid"`
 	LastProvenEpoch     int64    `db:"last_proven_epoch" json:"last_proven_epoch"`
 	NextChallengeEpoch  int64    `db:"next_challenge_epoch" json:"next_challenge_epoch"`
+	ChallengeRange      int64    `db:"challenge_range" json:"challenge_range"`
 	IsActive            bool      `db:"is_active" json:"is_active"`
 	CreatedAt           time.Time `db:"created_at" json:"created_at"`
 	UpdatedAt           time.Time `db:"updated_at" json:"updated_at"`

--- a/backend/indexer/internal/processor/handlers/fault_record_handler.go
+++ b/backend/indexer/internal/processor/handlers/fault_record_handler.go
@@ -150,6 +150,8 @@ func (h *FaultRecordHandler) HandleEvent(ctx context.Context, eventLog *types.Lo
 
 	challengeEpoch := proofSet.NextChallengeEpoch
 	proofSetOwner := proofSet.Owner
+	totalDataSize := proofSet.TotalDataSize
+
 
 	proofSet.TotalFaultedPeriods += periodsFaulted.Int64()
 	proofSet.UpdatedAt = faultedAt
@@ -177,8 +179,18 @@ func (h *FaultRecordHandler) HandleEvent(ctx context.Context, eventLog *types.Lo
 		}
 	}
 
-	// get challenged roots
-	challengedRoots, err := h.findChallengedRoots(ctx, setId, big.NewInt(challengeEpoch))
+	if totalDataSize.Sign() == 0 {
+		return nil
+	}
+	
+	// Calculate leaf count from data size
+	totalLeafCount, err := calculateLeafCount(totalDataSize)
+	if err != nil {
+		return err
+	}
+	
+	// Get challenged roots
+	challengedRoots, err := h.findChallengedRoots(ctx, setId, big.NewInt(challengeEpoch), totalLeafCount)
 	if err != nil {
 		return fmt.Errorf("failed to find challenged roots: %w", err)
 	}
@@ -253,7 +265,7 @@ func getUint256FromData(data string, offset int) (*big.Int, error) {
 // which root IDs are challenged this period for the given proof set.
 func (h *FaultRecordHandler) findChallengedRoots(
 	ctx context.Context,
-	proofSetID, nextChallengeEpoch *big.Int,
+	proofSetID, nextChallengeEpoch, totalLeafCount *big.Int,
 ) ([]int64, error) {
 
 	callOpts := &bind.CallOpts{Context: ctx}
@@ -268,11 +280,6 @@ func (h *FaultRecordHandler) findChallengedRoots(
 		return nil, fmt.Errorf("no randomness returned (seed empty)")
 	}
 
-	// Figure out how many leaves in the proof set (on chain)
-	totalLeafCount, err := h.pdpVerifier.GetChallengeRange(callOpts, proofSetID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get proof set leaf count: %w", err)
-	}
 	totalLeaves := totalLeafCount.Uint64()
 	if totalLeaves == 0 {
 		// No leaves means no roots to challenge, seems like this will never happen *shrug*
@@ -343,4 +350,21 @@ func padTo32Bytes(b []byte) []byte {
 	out := make([]byte, 32)
 	copy(out[32-len(b):], b)
 	return out
+}
+
+// calculateLeafCount computes the total leaf count from the data size
+// It returns an error if the data size is not divisible by the leaf size
+func calculateLeafCount(dataSize *big.Int) (*big.Int, error) {
+	leafSize := big.NewInt(int64(contract.LeafSize))
+	
+	// Check if data size is divisible by leaf size
+	remainder := new(big.Int).Mod(dataSize, leafSize)
+	if remainder.Sign() != 0 {
+		return nil, fmt.Errorf("data size (%s bytes) is not a multiple of leaf size (%d bytes)", 
+			dataSize.String(), contract.LeafSize)
+	}
+	
+	// Calculate leaf count
+	leafCount := new(big.Int).Div(dataSize, leafSize)
+	return leafCount, nil
 }

--- a/backend/indexer/internal/processor/handlers/next_proving_period_handler.go
+++ b/backend/indexer/internal/processor/handlers/next_proving_period_handler.go
@@ -40,7 +40,7 @@ func (h *NextProvingPeriodHandler) HandleEvent(ctx context.Context, eventLog *ty
 		return fmt.Errorf("invalid data length for NextProvingPeriod event")
 	}
 	nextEpoch := new(big.Int).SetBytes(data[:32]).Int64()
-	leafCount := new(big.Int).SetBytes(data[32:]).Uint64()
+	leafCount := new(big.Int).SetBytes(data[32:]).Int64()
 
 	dbEventData, err := json.Marshal(map[string]interface{}{
 		"setId":           setId.String(),
@@ -87,6 +87,7 @@ func (h *NextProvingPeriodHandler) HandleEvent(ctx context.Context, eventLog *ty
 		proofSet := proofSets[0]
 
 		proofSet.NextChallengeEpoch = nextEpoch
+		proofSet.ChallengeRange = leafCount
 		proofSet.UpdatedAt = createdAt
 		proofSet.BlockNumber = blockNumber
 		proofSet.BlockHash = eventLog.BlockHash

--- a/backend/indexer/internal/processor/handlers/proof_set_created_handler.go
+++ b/backend/indexer/internal/processor/handlers/proof_set_created_handler.go
@@ -148,6 +148,7 @@ func (h *ProofSetCreatedHandler) HandleEvent(ctx context.Context, eventLog *type
 		TotalFeePaid:        big.NewInt(0),
 		LastProvenEpoch:     0,
 		NextChallengeEpoch:  0,
+		ChallengeRange:      0,
 		IsActive:            true,
 		CreatedAt:           createdAt,
 		UpdatedAt:           createdAt,

--- a/backend/indexer/migrations/000201_add_challenge_range_to_proof_sets.down.sql
+++ b/backend/indexer/migrations/000201_add_challenge_range_to_proof_sets.down.sql
@@ -1,0 +1,6 @@
+-- Drop the index first
+DROP INDEX IF EXISTS idx_proof_sets_challenge_range;
+
+-- Remove the challengeRange column from proof_sets table
+ALTER TABLE proof_sets 
+DROP COLUMN IF EXISTS challenge_range;

--- a/backend/indexer/migrations/000201_add_challenge_range_to_proof_sets.up.sql
+++ b/backend/indexer/migrations/000201_add_challenge_range_to_proof_sets.up.sql
@@ -1,0 +1,15 @@
+-- Add challengeRange column to proof_sets table
+ALTER TABLE proof_sets 
+ADD COLUMN challenge_range BIGINT DEFAULT 0;
+
+-- Update existing records to have a default value
+UPDATE proof_sets 
+SET challenge_range = 0
+WHERE challenge_range IS NULL;
+
+-- Add an index for the new column for better query performance
+CREATE INDEX idx_proof_sets_challenge_range ON proof_sets(challenge_range);
+
+-- Update the updated_at timestamp for all modified rows
+UPDATE proof_sets 
+SET updated_at = CURRENT_TIMESTAMP;


### PR DESCRIPTION
This includes following changes -

-  add challenge_range column to proof_set
- set `challenge_range` equal to leaf count in `NextProvingPeriod` event's handler
- use `challenge_range` directly as leaf count to find challenged roots

This fixes the use of challengeRange at present for the historical recoveries