### PR TITLE
Fix: remove direct query params injection into sql queries

### DIFF
--- a/client/src/api/apiService.ts
+++ b/client/src/api/apiService.ts
@@ -222,7 +222,7 @@ export const getProofSetRoots = async (
   proofSetId: string,
   offset: number = 0,
   limit: number = 10,
-  orderBy: string = 'root_id',
+  orderBy: string = 'rootId',
   order: string = 'asc'
 ) => {
   const response = await getRequest(

--- a/client/src/pages/ProofSetDetails.tsx
+++ b/client/src/pages/ProofSetDetails.tsx
@@ -81,7 +81,7 @@ export const ProofSetDetails = () => {
             ITEMS_PER_PAGE
           ),
           getProofSetRoots(proofSetId, 0, ITEMS_PER_PAGE),
-          getProofSetRoots(proofSetId, 0, ROOTS_PER_PAGE, 'root_id', 'desc'),
+          getProofSetRoots(proofSetId, 0, ROOTS_PER_PAGE, 'rootId', 'desc'),
         ])
 
         if (!proofSetResponse?.data?.proofSet) {
@@ -185,7 +185,7 @@ export const ProofSetDetails = () => {
           proofSetId,
           0,
           totalRoots,
-          'root_id',
+          'rootId',
           'desc'
         )
         setHeatmapRoots(response.data.roots || [])


### PR DESCRIPTION
Fixes vulnerabilities to sql injection by - 

- validate `filter` and use as parameter instead of directly injecting into sql query
- validate `orderBy` and `order` before injecting into sql