### PR TITLE
Fix (reconcilation): avoid requesting future blocks from RPC node

### DIFF
--- a/backend/indexer/internal/indexer/block_processing.go
+++ b/backend/indexer/internal/indexer/block_processing.go
@@ -392,7 +392,11 @@ func (i *Indexer) reconcile(ctx context.Context, startHeight uint64, currentHeig
 			return err
 		}
 
-		blocks, err := i.getBlocksWithTransactions(height, height+maxBlocksPerBatch, true)
+		// Calculate the end height for the batch, ensuring it doesn't exceed currentHeight
+		targetEndHeight := min(height+maxBlocksPerBatch, currentHeight)
+
+		// Fetch blocks up to the calculated targetEndHeight
+		blocks, err := i.getBlocksWithTransactions(height, targetEndHeight, true)
 		if err != nil {
 			return fmt.Errorf("failed to get block %d: %w", height, err)
 		}


### PR DESCRIPTION
- Updated the reconcile logic to cap the requested block range at currentHeight.
- Prevents RPC errors ("requested a future epoch (beyond 'latest')") when the node tip is behind.