### PR TITLE
better pgx pool configs

### DIFF
--- a/backend/indexer/internal/infrastructure/database/postgres.go
+++ b/backend/indexer/internal/infrastructure/database/postgres.go
@@ -19,7 +19,7 @@ type PostgresDB struct {
 func NewPostgresDB(cfg *config.Config) (*PostgresDB, error) {
 	pgConfig, err := pgxpool.ParseConfig(cfg.DatabaseURL)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse database url: %v", err)
+		return nil, fmt.Errorf("unable to parse database url: %w", err)
 	}
 	pgConfig.MaxConnLifetime = 30 * time.Minute
 	pgConfig.MaxConns = 10


### PR DESCRIPTION
calibnet explorer was failing with:

```
2025-04-22T08:30:30+02:00 | error | Failed to start polling error="failed to process batch: failed to save block: failed to save block: failed to connect to `user=postgres database=postgres`: 127.0.0.1:5432 (localhost): dial error: dial tcp 127.0.0.1:5432: connect: connection refused"
2025-04-22T08:30:30+02:00 | warn  | Indexer stopped with error: failed to start polling: failed to process batch: failed to save block: failed to save block: failed to connect to `user=postgres database=postgres`: 127.0.0.1:5432 (localhost): dial error: dial tcp 127.0.0.1:5432: connect: connection refused
```

Let's try modifying the config values with more connections health checks and generous timeouts to see if this stops the issue.  @frrist if you have any recommendations to these settings they'd be appreciated, I don't have great pgx pool intuition yet.