### PR TITLE
Fix: challenge Index generation

### DIFF
--- a/backend/indexer/internal/processor/handlers/fault_record_handler.go
+++ b/backend/indexer/internal/processor/handlers/fault_record_handler.go
@@ -279,7 +279,7 @@ func (h *FaultRecordHandler) findChallengedRoots(
 	// Generate each random leaf index
 	challenges := make([]*big.Int, contract.NumChallenges)
 	for i := 0; i < contract.NumChallenges; i++ {
-		leafIdx := h.generateChallengeIndex(seed, proofSetID.Int64(), i, totalLeaves)
+		leafIdx := h.generateChallengeIndex(padTo32Bytes(seed), proofSetID.Int64(), i, totalLeaves)
 		challenges[i] = big.NewInt(leafIdx)
 	}
 


### PR DESCRIPTION
Fixes challenge Index generation for the cases where seed size is not exactly equals to 32 bytes.