### PR TITLE
feat: track data set lifecycle states

### DIFF
--- a/subgraph/.gitignore
+++ b/subgraph/.gitignore
@@ -25,6 +25,8 @@ yarn-error.log*
 # Testing
 coverage
 coverage.json
+tests/.bin/
+tests/.latest.json
 
 # Typechain
 typechain

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,3 +1,10 @@
+enum DataSetStatus {
+  EMPTY # Newly created dataset, no roots yet
+  READY # Dataset has roots and is ready for proving
+  PROVING # Proofs are currently expected for this dataset
+  DELETED # Dataset has been deleted on-chain
+}
+
 type DataSet @entity(immutable: false) {
   id: Bytes! # setId
   setId: BigInt! # uint256
@@ -6,6 +13,7 @@ type DataSet @entity(immutable: false) {
   leafCount: BigInt! # uint256
   challengeRange: BigInt! # uint256
   isActive: Boolean!
+  status: DataSetStatus!
   lastProvenEpoch: BigInt! # uint256
   nextChallengeEpoch: BigInt! # uint256
   # NOTE: Proving period tracking is strictly bound to FWSS contract

--- a/subgraph/src/pdp-verifier.ts
+++ b/subgraph/src/pdp-verifier.ts
@@ -5,7 +5,7 @@ import {
   ProofFeePaid as ProofFeePaidEvent,
   DataSetCreated as DataSetCreatedEvent,
   DataSetDeleted as DataSetDeletedEvent,
-  DataSetDeleted as DataSetEmptyEvent,
+  DataSetEmpty as DataSetEmptyEvent,
   StorageProviderChanged as StorageProviderChangedEvent,
   PiecesAdded as PiecesAddedEvent,
   PiecesRemoved as PiecesRemovedEvent,

--- a/subgraph/src/pdp-verifier.ts
+++ b/subgraph/src/pdp-verifier.ts
@@ -28,6 +28,7 @@ import {
 import { SumTree } from "./sumTree";
 import { LeafSize } from "../utils";
 import { validateCommPv2, unpaddedSize } from "../utils/cid";
+import { DataSetStatus } from "./types";
 
 // --- Helper Functions for ID Generation ---
 function getProofSetEntityId(setId: BigInt): Bytes {
@@ -108,6 +109,7 @@ export function handleDataSetCreated(event: DataSetCreatedEvent): void {
   proofSet.owner = providerEntityId; // Link to Provider via owner address (which is Provider's ID)
   proofSet.listener = listenerAddr;
   proofSet.isActive = true;
+  proofSet.status = DataSetStatus.EMPTY;
   proofSet.leafCount = BigInt.fromI32(0);
   proofSet.challengeRange = BigInt.fromI32(0);
   proofSet.lastProvenEpoch = BigInt.fromI32(0);
@@ -325,6 +327,7 @@ export function handleDataSetDeleted(event: DataSetDeletedEvent): void {
 
   // Update DataSet
   proofSet.isActive = false;
+  proofSet.status = DataSetStatus.DELETED;
   proofSet.owner = Bytes.empty();
   proofSet.totalRoots = BigInt.fromI32(0);
   proofSet.totalDataSize = BigInt.fromI32(0);
@@ -552,6 +555,9 @@ export function handleDataSetEmpty(event: DataSetEmptyEvent): void {
   if (proofSet) {
     const oldTotalDataSize = proofSet.totalDataSize; // Store size before zeroing
 
+    proofSet.status = DataSetStatus.EMPTY;
+    proofSet.nextChallengeEpoch = BigInt.fromI32(0);
+    proofSet.lastProvenEpoch = BigInt.fromI32(0);
     proofSet.totalRoots = BigInt.fromI32(0);
     proofSet.totalDataSize = BigInt.fromI32(0);
     proofSet.leafCount = BigInt.fromI32(0);
@@ -816,7 +822,10 @@ export function handleNextProvingPeriod(event: NextProvingPeriodEvent): void {
   // Update Data Set
   const proofSet = DataSet.load(proofSetEntityId);
   if (proofSet) {
-    proofSet.nextChallengeEpoch = challengeEpoch;
+    if (proofSet.leafCount.equals(BigInt.fromI32(0))) {
+      proofSet.lastProvenEpoch = BigInt.fromI32(0);
+      proofSet.nextChallengeEpoch = BigInt.fromI32(0);
+    }
     proofSet.challengeRange = leafCount;
 
     let periodsSkipped: BigInt = BigInt.zero();
@@ -825,6 +834,7 @@ export function handleNextProvingPeriod(event: NextProvingPeriodEvent): void {
 
     // Set firstDeadline if this is the first NextProvingPeriod call
     if (proofSet.firstDeadline.equals(BigInt.fromI32(0))) {
+      proofSet.status = DataSetStatus.PROVING;
       proofSet.firstDeadline = currentBlockNumber;
       // Set default values for proving period configuration
       // These could be loaded from contract state or configuration
@@ -1180,9 +1190,12 @@ export function handlePiecesAdded(event: PiecesAddedEvent): void {
   }
 
   // Update DataSet stats
-  proofSet.totalRoots = proofSet.totalRoots.plus(
-    BigInt.fromI32(addedRootCount)
-  ); // Use correct field name
+  const previousDataSize = proofSet.totalDataSize;
+  if (previousDataSize.equals(BigInt.zero())) {
+    // First piece added, mark as ready for proving
+    // status will change to PROVING in nextProvingPeriod call
+    proofSet.status = DataSetStatus.READY;
+  }
   proofSet.nextPieceId = proofSet.nextPieceId.plus(
     BigInt.fromI32(addedRootCount)
   );

--- a/subgraph/src/pdp-verifier.ts
+++ b/subgraph/src/pdp-verifier.ts
@@ -822,19 +822,12 @@ export function handleNextProvingPeriod(event: NextProvingPeriodEvent): void {
   // Update Data Set
   const proofSet = DataSet.load(proofSetEntityId);
   if (proofSet) {
-    proofSet.nextChallengeEpoch = challengeEpoch;
-    proofSet.challengeRange = leafCount;
-    if (proofSet.leafCount.equals(BigInt.fromI32(0))) {
-      proofSet.lastProvenEpoch = BigInt.fromI32(0);
-      proofSet.nextChallengeEpoch = BigInt.fromI32(0);
-    }
-
     let periodsSkipped: BigInt = BigInt.zero();
     let faultedPeriods: BigInt = BigInt.zero();
     let nextDeadline: BigInt;
 
-    // Set firstDeadline if this is the first NextProvingPeriod call
-    if (proofSet.firstDeadline.equals(BigInt.fromI32(0))) {
+    // initialize state for new data set
+    if (proofSet.nextDeadline.equals(BigInt.fromI32(0))) {
       proofSet.status = DataSetStatus.PROVING;
       proofSet.firstDeadline = currentBlockNumber;
       // Set default values for proving period configuration
@@ -857,16 +850,14 @@ export function handleNextProvingPeriod(event: NextProvingPeriodEvent): void {
         : periodsSkipped.plus(BigInt.fromI32(1));
     }
 
-    proofSet.nextDeadline = nextDeadline;
-    proofSet.currentDeadlineCount = proofSet.currentDeadlineCount.plus(
-      periodsSkipped.plus(BigInt.fromI32(1))
-    );
-
     // Create ProvingWindow entity for skipped and current period
-    for (let i = 0; i <= periodsSkipped.toI64(); i++) {
-      const deadlineCount = proofSet.currentDeadlineCount.minus(
-        periodsSkipped.minus(BigInt.fromI64(i))
-      );
+    const provingWindows = proofSet.leafCount.equals(BigInt.fromI32(0))
+      ? periodsSkipped
+      : periodsSkipped.plus(BigInt.fromI32(1));
+    for (let i = 0; i < provingWindows.toI64(); i++) {
+      const deadlineCount = proofSet.currentDeadlineCount
+        .plus(BigInt.fromI32(1))
+        .plus(BigInt.fromI64(i));
       const periodDeadline = proofSet.firstDeadline.plus(
         deadlineCount.times(proofSet.maxProvingPeriod)
       );
@@ -889,6 +880,34 @@ export function handleNextProvingPeriod(event: NextProvingPeriodEvent): void {
       provingWindow.save();
     }
 
+    proofSet.nextDeadline = nextDeadline;
+    proofSet.nextChallengeEpoch = challengeEpoch;
+    proofSet.challengeRange = leafCount;
+    proofSet.currentDeadlineCount = proofSet.currentDeadlineCount.plus(
+      periodsSkipped.plus(BigInt.fromI32(1))
+    );
+    proofSet.provenThisPeriod = false;
+    proofSet.totalFaultedPeriods =
+      proofSet.totalFaultedPeriods.plus(faultedPeriods);
+    proofSet.totalTransactions = proofSet.totalTransactions.plus(
+      BigInt.fromI32(1)
+    );
+    proofSet.totalEventLogs = proofSet.totalEventLogs.plus(BigInt.fromI32(1));
+    proofSet.updatedAt = currentTimestamp;
+    proofSet.blockNumber = currentBlockNumber;
+
+    // Check if data set is empty
+    if (proofSet.leafCount.equals(BigInt.fromI32(0))) {
+      proofSet.nextDeadline = BigInt.fromI32(0);
+      proofSet.nextChallengeEpoch = BigInt.fromI32(0);
+      proofSet.firstDeadline = BigInt.fromI32(0);
+      proofSet.maxProvingPeriod = BigInt.fromI32(0);
+      proofSet.challengeWindowSize = BigInt.fromI32(0);
+      proofSet.currentDeadlineCount = BigInt.fromI32(0);
+    }
+
+    proofSet.save();
+
     const provider = Provider.load(proofSet.owner);
     if (provider) {
       provider.totalFaultedPeriods =
@@ -900,17 +919,6 @@ export function handleNextProvingPeriod(event: NextProvingPeriodEvent): void {
       provider.blockNumber = currentBlockNumber;
       provider.save();
     }
-
-    proofSet.provenThisPeriod = false;
-    proofSet.totalFaultedPeriods =
-      proofSet.totalFaultedPeriods.plus(faultedPeriods);
-    proofSet.totalTransactions = proofSet.totalTransactions.plus(
-      BigInt.fromI32(1)
-    );
-    proofSet.totalEventLogs = proofSet.totalEventLogs.plus(BigInt.fromI32(1));
-    proofSet.updatedAt = currentTimestamp;
-    proofSet.blockNumber = currentBlockNumber;
-    proofSet.save();
 
     // update provider and proof set metrics
     const weekId = currentTimestamp.toI32() / 604800;
@@ -1201,7 +1209,7 @@ export function handlePiecesAdded(event: PiecesAddedEvent): void {
     BigInt.fromI32(addedRootCount)
   );
   proofSet.nextPieceId = proofSet.nextPieceId.plus(
-    BigInt.fromI32(rootsDataLength)
+    BigInt.fromI32(addedRootCount)
   );
   proofSet.totalDataSize = proofSet.totalDataSize.plus(totalDataSizeAdded);
   proofSet.leafCount = proofSet.leafCount.plus(

--- a/subgraph/src/pdp-verifier.ts
+++ b/subgraph/src/pdp-verifier.ts
@@ -35,7 +35,7 @@ function getProofSetEntityId(setId: BigInt): Bytes {
   return Bytes.fromByteArray(Bytes.fromBigInt(setId));
 }
 
-function getRootEntityId(setId: BigInt, rootId: BigInt): Bytes {
+export function getRootEntityId(setId: BigInt, rootId: BigInt): Bytes {
   return Bytes.fromUTF8(setId.toString() + "-" + rootId.toString());
 }
 
@@ -822,11 +822,12 @@ export function handleNextProvingPeriod(event: NextProvingPeriodEvent): void {
   // Update Data Set
   const proofSet = DataSet.load(proofSetEntityId);
   if (proofSet) {
+    proofSet.nextChallengeEpoch = challengeEpoch;
+    proofSet.challengeRange = leafCount;
     if (proofSet.leafCount.equals(BigInt.fromI32(0))) {
       proofSet.lastProvenEpoch = BigInt.fromI32(0);
       proofSet.nextChallengeEpoch = BigInt.fromI32(0);
     }
-    proofSet.challengeRange = leafCount;
 
     let periodsSkipped: BigInt = BigInt.zero();
     let faultedPeriods: BigInt = BigInt.zero();
@@ -1006,11 +1007,11 @@ export function handlePiecesAdded(event: PiecesAddedEvent): void {
   eventLog.address = event.address;
   eventLog.name = "piecesAdded";
   // Store simple representation of event params
-  let rootIdStrings: string[] = [];
+  let pieceIdStrings: string[] = [];
   for (let i = 0; i < rootIdsFromEvent.length; i++) {
-    rootIdStrings.push(rootIdsFromEvent[i].toString());
+    pieceIdStrings.push(rootIdsFromEvent[i].toString());
   }
-  eventLog.data = `{ "setId": "${setId.toString()}", "rootIds": [${rootIdStrings.join(",")}] }`;
+  eventLog.data = `{ "setId": "${setId.toString()}", "pieceIds": [${pieceIdStrings.join(",")}] }`;
   eventLog.logIndex = event.logIndex;
   eventLog.transactionHash = event.transaction.hash;
   eventLog.createdAt = event.block.timestamp;
@@ -1196,8 +1197,11 @@ export function handlePiecesAdded(event: PiecesAddedEvent): void {
     // status will change to PROVING in nextProvingPeriod call
     proofSet.status = DataSetStatus.READY;
   }
-  proofSet.nextPieceId = proofSet.nextPieceId.plus(
+  proofSet.totalRoots = proofSet.totalRoots.plus(
     BigInt.fromI32(addedRootCount)
+  );
+  proofSet.nextPieceId = proofSet.nextPieceId.plus(
+    BigInt.fromI32(rootsDataLength)
   );
   proofSet.totalDataSize = proofSet.totalDataSize.plus(totalDataSizeAdded);
   proofSet.leafCount = proofSet.leafCount.plus(

--- a/subgraph/src/types.ts
+++ b/subgraph/src/types.ts
@@ -1,0 +1,6 @@
+export class DataSetStatus {
+  static readonly EMPTY: string = "EMPTY";
+  static readonly READY: string = "READY";
+  static readonly PROVING: string = "PROVING";
+  static readonly DELETED: string = "DELETED";
+}

--- a/subgraph/tests/dataset-status.test.ts
+++ b/subgraph/tests/dataset-status.test.ts
@@ -409,4 +409,140 @@ describe("DataSetStatus Lifecycle Tests", () => {
 
     assert.fieldEquals("DataSet", dataSetId, "status", "READY");
   });
+
+  test("Lifecycle: Add roots → Empty → Add roots again (with event sequence)", () => {
+    // Step 1: Create dataset (status = EMPTY)
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(90),
+      BigInt.fromI32(0)
+    );
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+    assert.fieldEquals("DataSet", dataSetId, "status", "EMPTY");
+    assert.fieldEquals("DataSet", dataSetId, "totalRoots", "0");
+    assert.fieldEquals("DataSet", dataSetId, "leafCount", "0");
+    assert.fieldEquals("DataSet", dataSetId, "firstDeadline", "0");
+    assert.fieldEquals("DataSet", dataSetId, "nextDeadline", "0");
+
+    // Step 2: Add roots (status = EMPTY → READY)
+    let pieceIds1 = [ROOT_ID_1];
+    let rootsAddedEvent1 = createRootsAddedEvent(
+      SET_ID,
+      pieceIds1,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent1.block.timestamp = BigInt.fromI32(1678886500);
+    rootsAddedEvent1.block.number = BigInt.fromI32(150);
+    rootsAddedEvent1.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent1.transaction.hash = generateTxHash(91);
+    handlePiecesAdded(rootsAddedEvent1);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "READY");
+    assert.fieldEquals("DataSet", dataSetId, "totalRoots", "1");
+    assert.fieldEquals("DataSet", dataSetId, "leafCount", "327715");
+
+    // Step 3: NextProvingPeriod (status = READY → PROVING)
+    let nextProvingPeriodEvent1 = createNextProvingPeriodEvent(
+      SET_ID,
+      BigInt.fromI32(1),
+      BigInt.fromI32(327715),
+      CONTRACT_ADDRESS
+    );
+    nextProvingPeriodEvent1.block.timestamp = BigInt.fromI32(1678886600);
+    nextProvingPeriodEvent1.block.number = BigInt.fromI32(200);
+    nextProvingPeriodEvent1.logIndex = BigInt.fromI32(1);
+    nextProvingPeriodEvent1.transaction.hash = generateTxHash(92);
+    handleNextProvingPeriod(nextProvingPeriodEvent1);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "PROVING");
+    assert.fieldEquals("DataSet", dataSetId, "firstDeadline", "200");
+    assert.fieldEquals("DataSet", dataSetId, "nextDeadline", "440"); // 200 + 240
+    assert.fieldEquals("DataSet", dataSetId, "currentDeadlineCount", "1");
+
+    // Step 4: Dataset becomes empty (PiecesRemoved → DataSetEmpty → NextProvingPeriod in same tx)
+    // Simulate the event sequence from contract's nextProvingPeriod function
+
+    // Event 1: DataSetEmpty (emitted by contract)
+    let dataSetEmptyEvent = createDataSetEmptyEvent(SET_ID, CONTRACT_ADDRESS);
+    dataSetEmptyEvent.block.timestamp = BigInt.fromI32(1678886700);
+    dataSetEmptyEvent.block.number = BigInt.fromI32(250);
+    dataSetEmptyEvent.logIndex = BigInt.fromI32(1);
+    dataSetEmptyEvent.transaction.hash = generateTxHash(93);
+    handleDataSetEmpty(dataSetEmptyEvent);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "EMPTY");
+    assert.fieldEquals("DataSet", dataSetId, "totalRoots", "0");
+    assert.fieldEquals("DataSet", dataSetId, "leafCount", "0");
+    assert.fieldEquals("DataSet", dataSetId, "nextChallengeEpoch", "0");
+    assert.fieldEquals("DataSet", dataSetId, "lastProvenEpoch", "0");
+
+    // Event 2: NextProvingPeriod (same transaction, should handle empty dataset)
+    let nextProvingPeriodEvent2 = createNextProvingPeriodEvent(
+      SET_ID,
+      BigInt.fromI32(2),
+      BigInt.fromI32(0),
+      CONTRACT_ADDRESS
+    );
+    nextProvingPeriodEvent2.block.timestamp = BigInt.fromI32(1678886700);
+    nextProvingPeriodEvent2.block.number = BigInt.fromI32(250);
+    nextProvingPeriodEvent2.logIndex = BigInt.fromI32(2);
+    nextProvingPeriodEvent2.transaction.hash = generateTxHash(93); // Same tx hash
+    handleNextProvingPeriod(nextProvingPeriodEvent2);
+
+    // Verify dataset remains EMPTY and proving fields are reset
+    assert.fieldEquals("DataSet", dataSetId, "status", "EMPTY");
+    assert.fieldEquals("DataSet", dataSetId, "nextDeadline", "0");
+    assert.fieldEquals("DataSet", dataSetId, "nextChallengeEpoch", "0");
+    assert.fieldEquals("DataSet", dataSetId, "firstDeadline", "0");
+    assert.fieldEquals("DataSet", dataSetId, "maxProvingPeriod", "0");
+    assert.fieldEquals("DataSet", dataSetId, "challengeWindowSize", "0");
+    assert.fieldEquals("DataSet", dataSetId, "currentDeadlineCount", "0");
+    assert.fieldEquals("DataSet", dataSetId, "totalFaultedPeriods", "1");
+
+    // Step 5: Add roots again (status = EMPTY → READY)
+    let pieceIds2 = [BigInt.fromI32(201)];
+    let rootsAddedEvent2 = createRootsAddedEvent(
+      SET_ID,
+      pieceIds2,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent2.block.timestamp = BigInt.fromI32(1678886800);
+    rootsAddedEvent2.block.number = BigInt.fromI32(300);
+    rootsAddedEvent2.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent2.transaction.hash = generateTxHash(94);
+    handlePiecesAdded(rootsAddedEvent2);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "READY");
+    assert.fieldEquals("DataSet", dataSetId, "totalRoots", "1");
+    assert.fieldEquals("DataSet", dataSetId, "leafCount", "327715");
+
+    // Step 6: NextProvingPeriod again (status = READY → PROVING with new firstDeadline)
+    let nextProvingPeriodEvent3 = createNextProvingPeriodEvent(
+      SET_ID,
+      BigInt.fromI32(1), // Challenge epoch resets
+      BigInt.fromI32(327715),
+      CONTRACT_ADDRESS
+    );
+    nextProvingPeriodEvent3.block.timestamp = BigInt.fromI32(1678886900);
+    nextProvingPeriodEvent3.block.number = BigInt.fromI32(350);
+    nextProvingPeriodEvent3.logIndex = BigInt.fromI32(1);
+    nextProvingPeriodEvent3.transaction.hash = generateTxHash(95);
+    handleNextProvingPeriod(nextProvingPeriodEvent3);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "PROVING");
+    assert.fieldEquals("DataSet", dataSetId, "firstDeadline", "350"); // new firstDeadline, not 200
+    assert.fieldEquals("DataSet", dataSetId, "nextDeadline", "590"); // 350 + 240
+    assert.fieldEquals("DataSet", dataSetId, "currentDeadlineCount", "1"); // Resets to 1
+    assert.fieldEquals("DataSet", dataSetId, "maxProvingPeriod", "240");
+    assert.fieldEquals("DataSet", dataSetId, "challengeWindowSize", "20");
+  });
 });

--- a/subgraph/tests/dataset-status.test.ts
+++ b/subgraph/tests/dataset-status.test.ts
@@ -1,0 +1,412 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+} from "matchstick-as/assembly/index";
+import { BigInt, Address, Bytes } from "@graphprotocol/graph-ts";
+import {
+  handleDataSetCreated,
+  handlePiecesAdded,
+  handleNextProvingPeriod,
+  handleDataSetDeleted,
+  handleDataSetEmpty,
+} from "../src/pdp-verifier";
+import {
+  createDataSetCreatedEvent,
+  createRootsAddedEvent,
+  createNextProvingPeriodEvent,
+  createDataSetDeletedEvent,
+  createDataSetEmptyEvent,
+  generateTxHash,
+} from "./pdp-verifier-utils";
+
+const SET_ID = BigInt.fromI32(1);
+const ROOT_ID_1 = BigInt.fromI32(101);
+const SENDER_ADDRESS = Address.fromString(
+  "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"
+);
+const CONTRACT_ADDRESS = Address.fromString(
+  "0xb16081f360e3847006db660bae1c6d1b2e17ec2b"
+);
+const PROOF_SET_ID_BYTES = Bytes.fromBigInt(SET_ID);
+
+describe("DataSetStatus Lifecycle Tests", () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  test("handleDataSetCreated sets status to EMPTY", () => {
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(1),
+      BigInt.fromI32(0)
+    );
+
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+    assert.fieldEquals("DataSet", dataSetId, "status", "EMPTY");
+    assert.fieldEquals("DataSet", dataSetId, "isActive", "true");
+    assert.fieldEquals("DataSet", dataSetId, "totalDataSize", "0");
+  });
+
+  test("handlePiecesAdded transitions status from EMPTY to READY", () => {
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(10),
+      BigInt.fromI32(0)
+    );
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+    assert.fieldEquals("DataSet", dataSetId, "status", "EMPTY");
+
+    let pieceIds = [ROOT_ID_1];
+    let rootsAddedEvent = createRootsAddedEvent(
+      SET_ID,
+      pieceIds,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent.block.timestamp = BigInt.fromI32(1678886500);
+    rootsAddedEvent.block.number = BigInt.fromI32(150);
+    rootsAddedEvent.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent.transaction.hash = generateTxHash(11);
+
+    handlePiecesAdded(rootsAddedEvent);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "READY");
+    assert.fieldEquals("DataSet", dataSetId, "isActive", "true");
+  });
+
+  test("handleNextProvingPeriod transitions status from READY to PROVING", () => {
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(20),
+      BigInt.fromI32(0)
+    );
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let pieceIds = [ROOT_ID_1];
+    let rootsAddedEvent = createRootsAddedEvent(
+      SET_ID,
+      pieceIds,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent.block.timestamp = BigInt.fromI32(1678886500);
+    rootsAddedEvent.block.number = BigInt.fromI32(150);
+    rootsAddedEvent.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent.transaction.hash = generateTxHash(21);
+    handlePiecesAdded(rootsAddedEvent);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+    assert.fieldEquals("DataSet", dataSetId, "status", "READY");
+
+    let nextProvingPeriodEvent = createNextProvingPeriodEvent(
+      SET_ID,
+      BigInt.fromI32(200),
+      BigInt.fromI32(32),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(200),
+      BigInt.fromI32(1678886600),
+      generateTxHash(22),
+      BigInt.fromI32(0)
+    );
+
+    handleNextProvingPeriod(nextProvingPeriodEvent);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "PROVING");
+    assert.fieldEquals("DataSet", dataSetId, "isActive", "true");
+    assert.fieldEquals("DataSet", dataSetId, "firstDeadline", "200");
+  });
+
+  test("handleDataSetDeleted transitions status to DELETED", () => {
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(30),
+      BigInt.fromI32(0)
+    );
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let pieceIds = [ROOT_ID_1];
+    let rootsAddedEvent = createRootsAddedEvent(
+      SET_ID,
+      pieceIds,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent.block.timestamp = BigInt.fromI32(1678886500);
+    rootsAddedEvent.block.number = BigInt.fromI32(150);
+    rootsAddedEvent.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent.transaction.hash = generateTxHash(31);
+    handlePiecesAdded(rootsAddedEvent);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+    assert.fieldEquals("DataSet", dataSetId, "status", "READY");
+
+    let dataSetDeletedEvent = createDataSetDeletedEvent(
+      SET_ID,
+      BigInt.fromI32(32),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(200),
+      BigInt.fromI32(1678886700),
+      generateTxHash(32),
+      BigInt.fromI32(0)
+    );
+
+    handleDataSetDeleted(dataSetDeletedEvent);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "DELETED");
+    assert.fieldEquals("DataSet", dataSetId, "isActive", "false");
+    assert.fieldEquals("DataSet", dataSetId, "totalRoots", "0");
+    assert.fieldEquals("DataSet", dataSetId, "totalDataSize", "0");
+  });
+
+  test("handleDataSetEmpty transitions status to EMPTY", () => {
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(40),
+      BigInt.fromI32(0)
+    );
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let pieceIds = [ROOT_ID_1];
+    let rootsAddedEvent = createRootsAddedEvent(
+      SET_ID,
+      pieceIds,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent.block.timestamp = BigInt.fromI32(1678886500);
+    rootsAddedEvent.block.number = BigInt.fromI32(150);
+    rootsAddedEvent.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent.transaction.hash = generateTxHash(41);
+    handlePiecesAdded(rootsAddedEvent);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+    assert.fieldEquals("DataSet", dataSetId, "status", "READY");
+
+    let dataSetEmptyEvent = createDataSetEmptyEvent(
+      SET_ID,
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(200),
+      BigInt.fromI32(1678886700),
+      generateTxHash(42),
+      BigInt.fromI32(0)
+    );
+
+    handleDataSetEmpty(dataSetEmptyEvent);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "EMPTY");
+    assert.fieldEquals("DataSet", dataSetId, "totalRoots", "0");
+    assert.fieldEquals("DataSet", dataSetId, "totalDataSize", "0");
+    assert.fieldEquals("DataSet", dataSetId, "leafCount", "0");
+  });
+
+  test("handleDataSetDeleted from PROVING status transitions to DELETED", () => {
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(50),
+      BigInt.fromI32(0)
+    );
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let pieceIds = [ROOT_ID_1];
+    let rootsAddedEvent = createRootsAddedEvent(
+      SET_ID,
+      pieceIds,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent.block.timestamp = BigInt.fromI32(1678886500);
+    rootsAddedEvent.block.number = BigInt.fromI32(150);
+    rootsAddedEvent.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent.transaction.hash = generateTxHash(51);
+    handlePiecesAdded(rootsAddedEvent);
+
+    let nextProvingPeriodEvent = createNextProvingPeriodEvent(
+      SET_ID,
+      BigInt.fromI32(200),
+      BigInt.fromI32(32),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(200),
+      BigInt.fromI32(1678886600),
+      generateTxHash(52),
+      BigInt.fromI32(0)
+    );
+    handleNextProvingPeriod(nextProvingPeriodEvent);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+    assert.fieldEquals("DataSet", dataSetId, "status", "PROVING");
+
+    let dataSetDeletedEvent = createDataSetDeletedEvent(
+      SET_ID,
+      BigInt.fromI32(32),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(250),
+      BigInt.fromI32(1678886800),
+      generateTxHash(53),
+      BigInt.fromI32(0)
+    );
+
+    handleDataSetDeleted(dataSetDeletedEvent);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "DELETED");
+    assert.fieldEquals("DataSet", dataSetId, "isActive", "false");
+  });
+
+  test("handleDataSetEmpty from PROVING status transitions to EMPTY", () => {
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(60),
+      BigInt.fromI32(0)
+    );
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let pieceIds = [ROOT_ID_1];
+    let rootsAddedEvent = createRootsAddedEvent(
+      SET_ID,
+      pieceIds,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent.block.timestamp = BigInt.fromI32(1678886500);
+    rootsAddedEvent.block.number = BigInt.fromI32(150);
+    rootsAddedEvent.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent.transaction.hash = generateTxHash(61);
+    handlePiecesAdded(rootsAddedEvent);
+
+    let nextProvingPeriodEvent = createNextProvingPeriodEvent(
+      SET_ID,
+      BigInt.fromI32(200),
+      BigInt.fromI32(32),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(200),
+      BigInt.fromI32(1678886600),
+      generateTxHash(62),
+      BigInt.fromI32(0)
+    );
+    handleNextProvingPeriod(nextProvingPeriodEvent);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+    assert.fieldEquals("DataSet", dataSetId, "status", "PROVING");
+
+    let dataSetEmptyEvent = createDataSetEmptyEvent(
+      SET_ID,
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(250),
+      BigInt.fromI32(1678886800),
+      generateTxHash(63),
+      BigInt.fromI32(0)
+    );
+
+    handleDataSetEmpty(dataSetEmptyEvent);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "EMPTY");
+    assert.fieldEquals("DataSet", dataSetId, "totalRoots", "0");
+    assert.fieldEquals("DataSet", dataSetId, "totalDataSize", "0");
+  });
+
+  test("Status remains EMPTY when no pieces are added", () => {
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(70),
+      BigInt.fromI32(0)
+    );
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "EMPTY");
+    assert.fieldEquals("DataSet", dataSetId, "totalDataSize", "0");
+    assert.fieldEquals("DataSet", dataSetId, "leafCount", "0");
+  });
+
+  test("Multiple pieces added keeps status as READY", () => {
+    let mockDataSetCreatedEvent = createDataSetCreatedEvent(
+      SET_ID,
+      SENDER_ADDRESS,
+      Bytes.fromI32(123),
+      CONTRACT_ADDRESS,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1678886400),
+      generateTxHash(80),
+      BigInt.fromI32(0)
+    );
+    handleDataSetCreated(mockDataSetCreatedEvent);
+
+    let pieceIds1 = [ROOT_ID_1];
+    let rootsAddedEvent1 = createRootsAddedEvent(
+      SET_ID,
+      pieceIds1,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent1.block.timestamp = BigInt.fromI32(1678886500);
+    rootsAddedEvent1.block.number = BigInt.fromI32(150);
+    rootsAddedEvent1.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent1.transaction.hash = generateTxHash(81);
+    handlePiecesAdded(rootsAddedEvent1);
+
+    let dataSetId = PROOF_SET_ID_BYTES.toHex();
+    assert.fieldEquals("DataSet", dataSetId, "status", "READY");
+
+    let pieceIds2 = [BigInt.fromI32(102)];
+    let rootsAddedEvent2 = createRootsAddedEvent(
+      SET_ID,
+      pieceIds2,
+      SENDER_ADDRESS,
+      CONTRACT_ADDRESS
+    );
+    rootsAddedEvent2.block.timestamp = BigInt.fromI32(1678886600);
+    rootsAddedEvent2.block.number = BigInt.fromI32(160);
+    rootsAddedEvent2.logIndex = BigInt.fromI32(1);
+    rootsAddedEvent2.transaction.hash = generateTxHash(82);
+    handlePiecesAdded(rootsAddedEvent2);
+
+    assert.fieldEquals("DataSet", dataSetId, "status", "READY");
+  });
+});

--- a/subgraph/tests/fault-calculation.test.ts
+++ b/subgraph/tests/fault-calculation.test.ts
@@ -6,7 +6,7 @@ import {
   beforeEach,
   afterEach,
 } from "matchstick-as/assembly/index";
-import { BigInt, Address, Bytes, log } from "@graphprotocol/graph-ts";
+import { BigInt, Address, Bytes } from "@graphprotocol/graph-ts";
 import {
   handleDataSetCreated,
   handleNextProvingPeriod,

--- a/subgraph/tests/fault-calculation.test.ts
+++ b/subgraph/tests/fault-calculation.test.ts
@@ -6,7 +6,7 @@ import {
   beforeEach,
   afterEach,
 } from "matchstick-as/assembly/index";
-import { BigInt, Address, Bytes } from "@graphprotocol/graph-ts";
+import { BigInt, Address, Bytes, log } from "@graphprotocol/graph-ts";
 import {
   handleDataSetCreated,
   handleNextProvingPeriod,
@@ -127,7 +127,6 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
-
     addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const nextProvingPeriodEvent = createNextProvingPeriodEvent(
@@ -238,6 +237,7 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
+    addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const firstNextProvingPeriodEvent = createNextProvingPeriodEvent(
       SET_ID,
@@ -464,6 +464,7 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
+    addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const firstNextProvingPeriodEvent = createNextProvingPeriodEvent(
       SET_ID,
@@ -554,6 +555,7 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
+    addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const firstNextProvingPeriodEvent = createNextProvingPeriodEvent(
       SET_ID,
@@ -628,6 +630,7 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
+    addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const firstNextProvingPeriodEvent = createNextProvingPeriodEvent(
       SET_ID,
@@ -702,6 +705,7 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
+    addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const firstNextProvingPeriodEvent = createNextProvingPeriodEvent(
       SET_ID,

--- a/subgraph/tests/fault-calculation.test.ts
+++ b/subgraph/tests/fault-calculation.test.ts
@@ -10,16 +10,19 @@ import { BigInt, Address, Bytes } from "@graphprotocol/graph-ts";
 import {
   handleDataSetCreated,
   handleNextProvingPeriod,
+  handlePiecesAdded,
   handlePossessionProven,
 } from "../src/pdp-verifier";
 import {
   createDataSetCreatedEvent,
   createNextProvingPeriodEvent,
   createPossessionProvenEvent,
+  createRootsAddedEvent,
   generateTxHash,
 } from "./pdp-verifier-utils";
 
 const SET_ID = BigInt.fromI32(1);
+const ROOT_ID_1 = BigInt.fromI32(101);
 const PROVIDER_ADDRESS = Address.fromString(
   "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"
 );
@@ -31,6 +34,9 @@ const LISTENER_ADDRESS = Address.fromString(
 );
 const MAX_PROVING_PERIOD = BigInt.fromI32(240);
 const CHALLENGE_WINDOW_SIZE = BigInt.fromI32(20);
+const SENDER_ADDRESS = Address.fromString(
+  "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"
+);
 
 function getProofSetId(): string {
   return Bytes.fromBigInt(SET_ID).toHex();
@@ -38,6 +44,23 @@ function getProofSetId(): string {
 
 function getProviderId(): string {
   return PROVIDER_ADDRESS.toHex();
+}
+
+function addRootToDataSet(setId: BigInt, rootId: BigInt): void {
+  const rootsAddedEvent = createRootsAddedEvent(
+    setId,
+    [rootId],
+    SENDER_ADDRESS,
+    CONTRACT_ADDRESS
+  );
+
+  // Set block/tx details on the mock event if needed by handler
+  rootsAddedEvent.block.timestamp = BigInt.fromI32(100); // Example timestamp
+  rootsAddedEvent.block.number = BigInt.fromI32(50); // Example block number
+  rootsAddedEvent.logIndex = BigInt.fromI32(1); // Example log index
+  rootsAddedEvent.transaction.hash = Bytes.fromHexString("0x" + "c".repeat(64));
+
+  handlePiecesAdded(rootsAddedEvent);
 }
 
 describe("Fault Calculation Tests", () => {
@@ -104,6 +127,8 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
+
+    addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const nextProvingPeriodEvent = createNextProvingPeriodEvent(
       SET_ID,
@@ -293,6 +318,7 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
+    addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const firstNextProvingPeriodEvent = createNextProvingPeriodEvent(
       SET_ID,
@@ -308,7 +334,7 @@ describe("Fault Calculation Tests", () => {
 
     const possessionProvenEvent = createPossessionProvenEvent(
       SET_ID,
-      [BigInt.fromI32(0)],
+      [ROOT_ID_1],
       [BigInt.fromI32(100)],
       CONTRACT_ADDRESS,
       proofBlockNumber,
@@ -356,6 +382,7 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
+    addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const firstNextProvingPeriodEvent = createNextProvingPeriodEvent(
       SET_ID,
@@ -371,7 +398,7 @@ describe("Fault Calculation Tests", () => {
 
     const possessionProvenEvent = createPossessionProvenEvent(
       SET_ID,
-      [BigInt.fromI32(0)],
+      [ROOT_ID_1],
       [BigInt.fromI32(100)],
       CONTRACT_ADDRESS,
       proofBlockNumber,
@@ -837,6 +864,7 @@ describe("Fault Calculation Tests", () => {
       BigInt.fromI32(0)
     );
     handleDataSetCreated(dataSetCreatedEvent);
+    addRootToDataSet(SET_ID, ROOT_ID_1);
 
     const firstNextProvingPeriodEvent = createNextProvingPeriodEvent(
       SET_ID,
@@ -852,7 +880,7 @@ describe("Fault Calculation Tests", () => {
 
     const possessionProvenEvent1 = createPossessionProvenEvent(
       SET_ID,
-      [BigInt.fromI32(0)],
+      [ROOT_ID_1],
       [BigInt.fromI32(100)],
       CONTRACT_ADDRESS,
       proofBlockNumber1,
@@ -886,7 +914,7 @@ describe("Fault Calculation Tests", () => {
 
     const possessionProvenEvent2 = createPossessionProvenEvent(
       SET_ID,
-      [BigInt.fromI32(0)],
+      [ROOT_ID_1],
       [BigInt.fromI32(100)],
       CONTRACT_ADDRESS,
       proofBlockNumber2,

--- a/subgraph/tests/pdp-verifier-utils.ts
+++ b/subgraph/tests/pdp-verifier-utils.ts
@@ -6,6 +6,7 @@ import {
   NextProvingPeriod,
   PossessionProven,
   DataSetDeleted,
+  DataSetEmpty,
 } from "../generated/PDPVerifier/PDPVerifier";
 
 // Helper to generate unique transaction hash from a counter
@@ -246,8 +247,8 @@ export function createDataSetEmptyEvent(
   timestamp: BigInt = BigInt.fromI32(1),
   txHash: Bytes = generateTxHash(5),
   logIndex: BigInt = BigInt.fromI32(0)
-): DataSetDeleted {
-  let dataSetEmptyEvent = changetype<DataSetDeleted>(newMockEvent());
+): DataSetEmpty {
+  let dataSetEmptyEvent = changetype<DataSetEmpty>(newMockEvent());
 
   dataSetEmptyEvent.parameters = new Array();
 

--- a/subgraph/tests/pdp-verifier-utils.ts
+++ b/subgraph/tests/pdp-verifier-utils.ts
@@ -5,6 +5,7 @@ import {
   PiecesAdded,
   NextProvingPeriod,
   PossessionProven,
+  DataSetDeleted,
 } from "../generated/PDPVerifier/PDPVerifier";
 
 // Helper to generate unique transaction hash from a counter
@@ -79,11 +80,28 @@ export function createRootsAddedEvent(
     "pieceIds",
     ethereum.Value.fromUnsignedBigIntArray(pieceIds)
   );
+
+  let pieceCids: Array<ethereum.Tuple> = [];
+  for (let i = 0; i < pieceIds.length; i++) {
+    let cidTuple = new ethereum.Tuple();
+    let cidData = Bytes.fromHexString(
+      "0x01559120258ff7f7021387dcea7164b7d1c4a98bd6f8d3c187e3114795efa391df307c8aa9d5d5cbac03"
+    );
+    cidTuple.push(ethereum.Value.fromBytes(cidData));
+    pieceCids.push(cidTuple);
+  }
+
+  let pieceCidsParam = new ethereum.EventParam(
+    "pieceCids",
+    ethereum.Value.fromTupleArray(pieceCids)
+  );
+
   rootsAddedEvent.parameters.push(setIdParam);
   rootsAddedEvent.parameters.push(rootIdsParam);
+  rootsAddedEvent.parameters.push(pieceCidsParam);
 
   let txInputHex =
-    "0x11c0ee4a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000016000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000fe000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000270181e20392202015ef4cc07f475ed2ee3ad23cfbb7fbffd6707bf8207743d6e4a4640b3742e709000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+    "0x9afd37f20000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002a01559120258ff7f7021387dcea7164b7d1c4a98bd6f8d3c187e3114795efa391df307c8aa9d5d5cbac030000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002a05f13cbf0c320f1092664967af5de13e4abe964d4f755c0d4cffe18a146f395030000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000002200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b69706673526f6f744349440000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003b626166796265696537696d32766e766870347a726d6778776c6b336d6133736f736f6e743765367776726f63336134756261707a7a7a3368796a75000000000000000000000000000000000000000000000000000000000000000000000000411b4c7e389fe7383d20d251599c194c9ddb3e71d79c2c1b44fe15b0f505aea92e525239a7e91647c64370054fe8a779486342fafb8971a7eb69101c97368c4bf61b00000000000000000000000000000000000000000000000000000000000000";
   let txInput = Bytes.fromHexString(txInputHex);
   rootsAddedEvent.transaction.input = txInput;
 
@@ -181,4 +199,74 @@ export function createPossessionProvenEvent(
   possessionProvenEvent.logIndex = logIndex;
 
   return possessionProvenEvent;
+}
+
+export function createDataSetDeletedEvent(
+  setId: BigInt,
+  deletedLeafCount: BigInt,
+  contractAddress: Address,
+  blockNumber: BigInt = BigInt.fromI32(1),
+  timestamp: BigInt = BigInt.fromI32(1),
+  txHash: Bytes = generateTxHash(4),
+  logIndex: BigInt = BigInt.fromI32(0)
+): DataSetDeleted {
+  let dataSetDeletedEvent = changetype<DataSetDeleted>(newMockEvent());
+
+  dataSetDeletedEvent.parameters = new Array();
+
+  let setIdParam = new ethereum.EventParam(
+    "setId",
+    ethereum.Value.fromUnsignedBigInt(setId)
+  );
+  let deletedLeafCountParam = new ethereum.EventParam(
+    "deletedLeafCount",
+    ethereum.Value.fromUnsignedBigInt(deletedLeafCount)
+  );
+
+  dataSetDeletedEvent.parameters.push(setIdParam);
+  dataSetDeletedEvent.parameters.push(deletedLeafCountParam);
+
+  dataSetDeletedEvent.address = contractAddress;
+  dataSetDeletedEvent.block.number = blockNumber;
+  dataSetDeletedEvent.block.timestamp = timestamp;
+  dataSetDeletedEvent.transaction.hash = txHash;
+  dataSetDeletedEvent.logIndex = logIndex;
+  dataSetDeletedEvent.transaction.from = Address.fromString(
+    "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"
+  );
+  dataSetDeletedEvent.transaction.to = contractAddress;
+
+  return dataSetDeletedEvent;
+}
+
+export function createDataSetEmptyEvent(
+  setId: BigInt,
+  contractAddress: Address,
+  blockNumber: BigInt = BigInt.fromI32(1),
+  timestamp: BigInt = BigInt.fromI32(1),
+  txHash: Bytes = generateTxHash(5),
+  logIndex: BigInt = BigInt.fromI32(0)
+): DataSetDeleted {
+  let dataSetEmptyEvent = changetype<DataSetDeleted>(newMockEvent());
+
+  dataSetEmptyEvent.parameters = new Array();
+
+  let setIdParam = new ethereum.EventParam(
+    "setId",
+    ethereum.Value.fromUnsignedBigInt(setId)
+  );
+
+  dataSetEmptyEvent.parameters.push(setIdParam);
+
+  dataSetEmptyEvent.address = contractAddress;
+  dataSetEmptyEvent.block.number = blockNumber;
+  dataSetEmptyEvent.block.timestamp = timestamp;
+  dataSetEmptyEvent.transaction.hash = txHash;
+  dataSetEmptyEvent.logIndex = logIndex;
+  dataSetEmptyEvent.transaction.from = Address.fromString(
+    "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"
+  );
+  dataSetEmptyEvent.transaction.to = contractAddress;
+
+  return dataSetEmptyEvent;
 }

--- a/subgraph/tests/pdp-verifier.test.ts
+++ b/subgraph/tests/pdp-verifier.test.ts
@@ -7,20 +7,23 @@ import {
   afterAll,
 } from "matchstick-as/assembly/index";
 import { BigInt, Address, Bytes, ByteArray } from "@graphprotocol/graph-ts";
-import { Root, DataSet, Provider, EventLog } from "../generated/schema";
-import { handlePiecesAdded, handleDataSetCreated } from "../src/pdp-verifier";
+import {
+  handlePiecesAdded,
+  handleDataSetCreated,
+  getRootEntityId,
+} from "../src/pdp-verifier";
 import {
   createRootsAddedEvent,
   createDataSetCreatedEvent,
 } from "./pdp-verifier-utils";
 
 // Define constants for test data
-const SET_ID = BigInt.fromI32(0);
+const SET_ID = BigInt.fromI32(1);
 const ROOT_ID_1 = BigInt.fromI32(101);
-const RAW_SIZE_1 = BigInt.fromI32(1040384);
+const RAW_SIZE_1 = BigInt.fromI32(10486897);
 // CIDs as strings
 const ROOT_CID_1_STR =
-  "0x0181e20392202015ef4cc07f475ed2ee3ad23cfbb7fbffd6707bf8207743d6e4a4640b3742e709";
+  "0x01559120258ff7f7021387dcea7164b7d1c4a98bd6f8d3c187e3114795efa391df307c8aa9d5d5cbac03";
 const SENDER_ADDRESS = Address.fromString(
   "0xa16081f360e3847006db660bae1c6d1b2e17ec2a"
 );
@@ -31,12 +34,6 @@ const CONTRACT_ADDRESS = Address.fromString(
   "0xb16081f360e3847006db660bae1c6d1b2e17ec2b"
 );
 const PROOF_SET_ID_BYTES = Bytes.fromBigInt(SET_ID);
-
-// Helper function to create Root entity ID
-function createRootEntityId(proofSetIdBytes: Bytes, rootId: BigInt): Bytes {
-  // .concatI32 returns ByteArray, which needs to be converted back to Bytes
-  return Bytes.fromByteArray(proofSetIdBytes.concatI32(rootId.toI32()));
-}
 
 // Helper to convert string to Bytes and pad to 32 bytes
 function stringToBytes32(str: string): Bytes {
@@ -109,10 +106,7 @@ describe("handlePiecesAdded Tests", () => {
     assert.fieldEquals("DataSet", dataSetId, "blockNumber", "50");
 
     // --- Assert Root fields ---
-    let rootEntityId1 = createRootEntityId(
-      Bytes.fromByteArray(PROOF_SET_ID_BYTES),
-      ROOT_ID_1
-    ).toHex();
+    let rootEntityId1 = getRootEntityId(SET_ID, ROOT_ID_1).toHex();
     assert.fieldEquals("Root", rootEntityId1, "rootId", ROOT_ID_1.toString());
     assert.fieldEquals("Root", rootEntityId1, "setId", SET_ID.toString());
     assert.fieldEquals("Root", rootEntityId1, "cid", ROOT_CID_1_STR);


### PR DESCRIPTION
## Summary 
This PR introduces a comprehensive dataset lifecycle tracking system, enabling better monitoring and querying of dataset states throughout their lifecycle.

## Breaking Changes
None. This is a backward-compatible addition to the schema.

## Additional Notes
The dataset lifecycle tracking enables better UX/DX  by allowing queries to filter datasets by their current state. For example:

- Filter out empty datasets (`status: EMPTY`)
- Show only active datasets ready for proving (`status: READY`)
- Display datasets currently in proving period (`status: PROVING`)
- Filter out deleted datasets (`status: DELETED`)

This implementation maintains backward compatibility while adding valuable state tracking capabilities to the subgraph.

Related to #89 