### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 5
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: npm
+    directory: /
+    open-pull-requests-limit: 5
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      safe-workspace-updates:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@biomejs/biome" # Required manual schema updates & can fail CI
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /subgraph-client
+    open-pull-requests-limit: 5
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      safe-workspace-updates:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This PR intentionally skips `/subgraph` dependencies because higher `assemblyscript` versions aren't stable with subgraph setup. See - https://github.com/FilOzone/filecoin-pay-explorer/pull/203