### PR TITLE
fix: configure Vercel SPA rewrites

### DIFF
--- a/subgraph-client/vercel.json
+++ b/subgraph-client/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary

- add Vercel project configuration for the frontend
- rewrite all application routes to `index.html` so React Router handles direct navigation and refreshes

## Why

The frontend uses `BrowserRouter`. Without a server-side SPA fallback, direct requests to nested routes such as `/mainnet/providers` return a platform 404 on Vercel.