### PR TITLE
chore: use PDP production domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PDP Explorer
 
-https://pdp.vxb.ai
+https://pdp.filecoin.cloud
 
 Data model and UI for exploring the PDP hot storage network.
 

--- a/subgraph-client/index.html
+++ b/subgraph-client/index.html
@@ -12,14 +12,14 @@
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://pdpscan.vercel.app/" />
+  <meta property="og:url" content="https://pdp.filecoin.cloud/" />
   <meta property="og:title" content="PDP Scan | Filecoin Data Possession Explorer" />
   <meta property="og:description"
     content="Track Proof of Data Possession (PDP) metrics, providers, and proof sets on the Filecoin network." />
 
   <!-- Twitter -->
   <meta property="twitter:card" content="summary_large_image" />
-  <meta property="twitter:url" content="https://pdpscan.vercel.app/" />
+  <meta property="twitter:url" content="https://pdp.filecoin.cloud/" />
   <meta property="twitter:title" content="PDP Scan | Filecoin Data Possession Explorer" />
   <meta property="twitter:description"
     content="Track Proof of Data Possession (PDP) metrics, providers, and proof sets on the Filecoin network." />

--- a/subgraph-client/public/robots.txt
+++ b/subgraph-client/public/robots.txt
@@ -6,4 +6,4 @@ Allow: /
 Crawl-delay: 1
 
 # Sitemap location
-Sitemap: https://pdpscan.vercel.app/sitemap.xml
+Sitemap: https://pdp.filecoin.cloud/sitemap.xml

--- a/subgraph-client/public/sitemap.xml
+++ b/subgraph-client/public/sitemap.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://pdpscan.vercel.app/</loc>
+    <loc>https://pdp.filecoin.cloud/</loc>
     <lastmod>2025-04-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://pdpscan.vercel.app/providers</loc>
+    <loc>https://pdp.filecoin.cloud/providers</loc>
     <lastmod>2025-04-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://pdpscan.vercel.app/dataset</loc>
+    <loc>https://pdp.filecoin.cloud/dataset</loc>
     <lastmod>2025-04-28</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>

--- a/subgraph-client/vercel.json
+++ b/subgraph-client/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary

- replace legacy PDP Explorer URLs with `https://pdp.filecoin.cloud`
- update Open Graph and Twitter metadata
- update the robots sitemap reference and sitemap entries
- update the repository README site link

## Stacked PR

- depends on #146
- base branch: `phi/vercel-spa-routing`
- merge after the Vercel deployment and `pdp.filecoin.cloud` DNS setup are ready

## Impact

Public metadata, crawler configuration, and repository documentation will identify the new production domain instead of the previous Vercel and temporary deployment URLs.

## Validation

- `npm run check:ci`
- `npm run build` in `subgraph-client` with the production environment variables
- confirmed no `pdpscan.vercel.app` or `pdp.vxb.ai` references remain
